### PR TITLE
fix: add missing import in examples.

### DIFF
--- a/docs/components/demo/basic/index.vue
+++ b/docs/components/demo/basic/index.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { Motion } from 'motion-v'
 </script>
 
 <template>

--- a/docs/components/demo/hover/index.vue
+++ b/docs/components/demo/hover/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-
+import { Motion } from 'motion-v'
 </script>
 
 <template>

--- a/docs/components/demo/press/index.vue
+++ b/docs/components/demo/press/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-
+import { Motion } from 'motion-v'
 </script>
 
 <template>

--- a/docs/components/demo/while-drag/index.vue
+++ b/docs/components/demo/while-drag/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-
+import { Motion } from 'motion-v'
 </script>
 
 <template>


### PR DESCRIPTION
Hi, while trying out a couple of examples locally, I noticed that the import was missing.