### PR TITLE
docs: add useSpring + Motion Value Overview

### DIFF
--- a/docs/components/demo/use-spring/index.vue
+++ b/docs/components/demo/use-spring/index.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { Motion, delay } from 'motion-v'
+
+const spring = { damping: 3, stiffness: 50, restDelta: 0.001 }
+const scaleValue = useMotionValue(0)
+const scale = useSpring(scaleValue, spring)
+
+delay(() => {
+  scale.set(1)
+}, 0.5)
+</script>
+
+<template>
+  <Motion
+    as="div"
+    :style="{
+      scale,
+    }"
+    class="size-20 bg-primary rounded-full"
+  />
+</template>

--- a/docs/components/demo/use-spring/index.vue
+++ b/docs/components/demo/use-spring/index.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
-import { Motion, delay } from 'motion-v'
+import { Motion, useSpring } from 'motion-v'
 
 const spring = { damping: 3, stiffness: 50, restDelta: 0.001 }
 const scaleValue = useMotionValue(0)
 const scale = useSpring(scaleValue, spring)
 
-delay(() => {
-  scale.set(1)
-}, 0.5)
+scale.set(1)
 </script>
 
 <template>

--- a/docs/components/layout/IsLand.vue
+++ b/docs/components/layout/IsLand.vue
@@ -19,7 +19,7 @@ const open = ref(false)
 const scrollPercentage = ref(0)
 const { scrollYProgress } = useScroll()
 
-useMotionValueEvent(scrollYProgress, 'change', (value) => {
+useMotionValue(scrollYProgress, 'change', (value) => {
   scrollPercentage.value = value
 })
 

--- a/docs/content/4.motion-value/0.overview.md
+++ b/docs/content/4.motion-value/0.overview.md
@@ -1,0 +1,11 @@
+---
+title: Overview
+description:
+navigation.icon: 'lucide:info'
+---
+
+Motion values track the state and velocity of animated values.
+
+They are composable, signal-like values that are performant because Motion can render them with its optimised DOM renderer.
+
+Usually, these are created automatically by motion components. But for advanced use cases, it's possible to create them manually.

--- a/docs/content/4.motion-value/0.overview.md
+++ b/docs/content/4.motion-value/0.overview.md
@@ -53,7 +53,7 @@ const opacity = useTransform(
 
 ## Usage
 
-Motion values can be created with the [`useMotionValueEvent`](/motion-value/use-motion-value-event) composable. The string or number passed to `useMotionValue` will act as its initial state.
+Motion values can be created with the [`useMotionValue`](/motion-value/use-motion-value-event) composable. The string or number passed to `useMotionValue` will act as its initial state.
 
 ```ts
 import { useMotionValue } from 'motion-v'
@@ -99,10 +99,10 @@ For strings and colors, `getVelocity` will always return 0.
 
 ### Events
 
-Listeners can be added to motion values via the `on` method or the [`useMotionValueEvent`](/motion-value/use-motion-value-event) composable.
+Listeners can be added to motion values via the `on` method or the [`useMotionValue`](/motion-value/use-motion-value-event) composable.
 
 ```ts
-useMotionValueEvent(x, 'change', latest => console.log(latest))
+useMotionValue(x, 'change', latest => console.log(latest))
 ```
 Available events are `"change"`, `"animationStart"`, `"animationComplete"` `"animationCancel"`.
 
@@ -182,7 +182,7 @@ It returns a function that, when called, will unsubscribe the listener.
 const unsubscribe = x.on('change', latest => console.log(latest))
 ```
 
-You can `on` inside a vue component, or instead use the [`useMotionValueEvent`](/motion-value/use-motion-value-event) composable.
+You can `on` inside a vue component, or instead use the [`useMotionValue`](/motion-value/use-motion-value-event) composable.
 
 ### `destroy()`
 

--- a/docs/content/4.motion-value/0.overview.md
+++ b/docs/content/4.motion-value/0.overview.md
@@ -9,3 +9,5 @@ Motion values track the state and velocity of animated values.
 They are composable, signal-like values that are performant because Motion can render them with its optimised DOM renderer.
 
 Usually, these are created automatically by motion components. But for advanced use cases, it's possible to create them manually.
+
+### jump()

--- a/docs/content/4.motion-value/0.overview.md
+++ b/docs/content/4.motion-value/0.overview.md
@@ -10,4 +10,182 @@ They are composable, signal-like values that are performant because Motion can r
 
 Usually, these are created automatically by motion components. But for advanced use cases, it's possible to create them manually.
 
-### jump()
+```vue
+<script setup lang="ts">
+import { useMotionValue } from 'motion-v'
+
+const x = useMotionValue(0)
+</script>
+
+<template>
+  <Motion
+    style:="{ x }"
+  />
+</template>
+```
+
+By manually creating motion values you can:
+
+- Set and get their state.
+- Pass to multiple components to synchronise motion across them.
+- Chain `MotionValues` via the `useTransform` composable.
+- Update visual properties without triggering a render cycle.
+- Subscribe to updates.
+
+```vue
+<script setup lang="ts">
+import { useMotionValue, useTransform } from 'motion-v'
+
+const x = useMotionValue(0)
+const opacity = useTransform(
+  x,
+  [-200, 0, 200],
+  [0, 1, 0]
+)
+</script>
+
+<template>
+  <Motion
+    style:="{ x, opacity }"
+  />
+</template>
+```
+
+## Usage
+
+Motion values can be created with the [`useMotionValueEvent`](/motion-value/use-motion-value-event) composable. The string or number passed to `useMotionValue` will act as its initial state.
+
+```ts
+import { useMotionValue } from 'motion-v'
+
+const x = useMotionValue(0)
+```
+
+Motion values can be passed to a `Motion` component via `style`:
+
+```vue
+<Motion :style={{ x }} />
+```
+
+Or for SVG attributes, via the attribute prop itself:
+
+```vue
+<Motion as="circle" :cx={{ x }} />
+```
+
+It's possible to pass the same motion value to multiple components.
+
+Motion values can be updated with the `set` method.
+
+```ts
+x.set(100)
+```
+
+Changes to the motion value will update the DOM **without triggering a re-render**. Motion values can be updated multiple times but renders will be batched to the next animation frame.
+
+A motion value can hold any string or number. We can read it with the `get` method.
+
+```ts
+x.get() // 100
+```
+
+Motion values containing a number can return a velocity via the `getVelocity` method. This returns the velocity as calculated per second to account for variations in frame rate across devices.
+
+```ts
+const xVelocity = x.getVelocity()
+```
+
+For strings and colors, `getVelocity` will always return 0.
+
+### Events
+
+Listeners can be added to motion values via the `on` method or the [`useMotionValueEvent`](/motion-value/use-motion-value-event) composable.
+
+```ts
+useMotionValueEvent(x, 'change', latest => console.log(latest))
+```
+Available events are `"change"`, `"animationStart"`, `"animationComplete"` `"animationCancel"`.
+
+### Composition
+
+Beyond `useMotionValue`, Motion Vue provides a number of composables for creating and composing motion values, like [useSpring](/motion-value/use-spring) and [useTransform](/motion-value/use-transform).
+
+For example, with `useTransform` we can take the latest state of one or more motion values and create a new motion value with the result.
+
+```ts
+const y = useTransform(() => x.get() * 2)
+```
+
+`useSpring` can make a motion value that's attached to another via a spring.
+
+```ts
+const dragX = useMotionValue(0)
+const dragY = useMotionValue(0)
+const x = useSpring(dragX)
+const y = useSpring(dragY)
+```
+
+These motion values can then go on to be passed to motion components, or composed with more composables like `useVelocity`.
+
+## API
+
+### `get()`
+
+Returns the latest state of the motion value.
+
+### `getVelocity()`
+
+Returns the latest velocity of the motion value. Returns `0` if the value is non-numerical.
+
+### `set()`
+
+Sets the motion value to a new state.
+
+```ts
+x.set('#f00')
+```
+
+### `jump()`
+
+Jumps the motion value to a new state in a way that breaks continuity from previous values:
+
+- Resets velocity to 0.
+- Ends active animations.
+- Ignores attached effects (for instance useSpring's spring).
+
+```ts
+const x = useSpring(0)
+x.jump(10)
+x.getVelocity() // 0
+```
+
+### `isAnimating()`
+
+Returns `true` if the value is currently animating.
+
+### `stop()`
+
+Stop the active animation.
+
+### `on()`
+
+Subscribe to motion value events. Available events are:
+
+- change
+- animationStart
+- animationCancel
+- animationComplete
+
+It returns a function that, when called, will unsubscribe the listener.
+
+```ts
+const unsubscribe = x.on('change', latest => console.log(latest))
+```
+
+You can `on` inside a vue component, or instead use the [`useMotionValueEvent`](/motion-value/use-motion-value-event) composable.
+
+### `destroy()`
+
+Destroy and clean up subscribers to this motion value.
+
+This is normally handled automatically, so this method is only necessary if you've manually created a motion value outside the render cycle using the vanilla `motionValue` composable.

--- a/docs/content/4.motion-value/3.use-scroll.md
+++ b/docs/content/4.motion-value/3.use-scroll.md
@@ -33,7 +33,7 @@ By default, `useScroll` tracks the page scroll.
 ```ts
 const { scrollY } = useScroll()
 
-useMotionValueEvent(scrollY, 'change', (latest) => {
+useMotionValue(scrollY, 'change', (latest) => {
   console.log('Page scroll: ', latest)
 })
 ```

--- a/docs/content/4.motion-value/4.use-spring.md
+++ b/docs/content/4.motion-value/4.use-spring.md
@@ -4,4 +4,14 @@ description:
 navigation.icon: 'lucide:move-3d'
 ---
 
+`useSpring` creates a [motion value](/motion-value/overview) that will animate to its latest target with a spring animation.
+
+The target can either be set manually via `.set`, or automatically by passing in another motion value.
+
+## Usage
+
+<ComponentPreview name="use-spring" />
+
+## Reference
+
 - [Motion React-useSpring](https://motion.dev/docs/react-use-spring)

--- a/docs/content/4.motion-value/4.use-spring.md
+++ b/docs/content/4.motion-value/4.use-spring.md
@@ -8,10 +8,81 @@ navigation.icon: 'lucide:move-3d'
 
 The target can either be set manually via `.set`, or automatically by passing in another motion value.
 
+<ComponentPreview name="use-spring" />
+
 ## Usage
 
-<ComponentPreview name="use-spring" />
+Import `useSpring` from Motion Vue:
+
+```ts
+import { useSpring } from 'motion-v'
+```
+
+### Direct control
+
+useSpring can be created with a number, or a unit-type (px, % etc) string:
+
+```ts
+const x = useSpring(0)
+const y = useSpring('100vh')
+```
+
+Now, whenever this motion value is updated via `set()`, the value will animate to its new target with the defined spring.
+
+```ts
+x.set(100)
+y.set('50vh')
+```
+
+It's also possible to update this value immediately, without a spring, with [the `jump()` method](/motion-value/overview#jump).
+
+```ts
+x.jump(50)
+y.jump('0vh')
+```
+
+### Track another motion value
+
+Its also possible to automatically spring towards the latest value of another motion value:
+
+```ts
+const x = useMotionValue(0)
+const y = useSpring(x)
+```
+
+This source motion value must also be a number, or unit-type string.
+
+## Options
+
+The spring can be configured with a number of options. For whole reference, refer to [motion's docs](https://motion.dev/docs/spring#options).
+
+```ts
+useSpring(0, {
+  stiffness: 300,
+  damping: 100,
+  mass: 10,
+})
+```
+
+### `damping`
+
+**Default:** `10`
+
+Strength of opposing force. If set to 0, spring will oscillate indefinitely.
+
+### `mass`
+
+**Default:** `1`
+
+Mass of the moving object. Higher values will result in more lethargic movement.
+
+### `stiffness`
+
+**Default:** `1`
+
+Stiffness of the spring. Higher values will create more sudden movement.
 
 ## Reference
 
+- [Motion](https://motion.dev/docs/spring)
 - [Motion React-useSpring](https://motion.dev/docs/react-use-spring)

--- a/docs/pages/[...slug].vue
+++ b/docs/pages/[...slug].vue
@@ -34,7 +34,7 @@ defineOgImageComponent(config.value.site.ogImageComponent, {
     class="relative py-6"
     :class="[config.toc.enable && (page.toc ?? true) && 'lg:grid lg:grid-cols-[1fr_220px] lg:gap-14 lg:py-8']"
   >
-    <div class="mx-auto w-full min-w-0">
+    <div class="mx-auto w-full min-w-0 max-w-xl">
       <LayoutBreadcrumb
         v-if="page?.body && config.main.breadCrumb && (page.breadcrumb ?? true)"
         class="mb-4"


### PR DESCRIPTION
Adds docs for `useSpring` and `motion values` (overview page).

## Screenshot

<img width="1222" alt="Screenshot 2025-02-24 at 21 58 36" src="https://github.com/user-attachments/assets/1fb710c2-d0a6-488a-9519-bb50cf14f736" />

## Issue

https://github.com/unovue/motion-vue/issues/78