### PR TITLE
fix(AnimatePresence): update motion snapshots on exit finalization for LayoutGroup

### DIFF
--- a/packages/motion/src/components/animate-presence/use-presence-container.ts
+++ b/packages/motion/src/components/animate-presence/use-presence-container.ts
@@ -98,6 +98,9 @@ export function usePresenceContainer(props: AnimatePresenceProps) {
   function finalizeExit(containerState: ContainerState) {
     // Remove pop style
     removePopStyle(containerState.el)
+    containerState.motions.forEach((state) => {
+      state.getSnapshot(state.options, false)
+    })
     // Call done to remove DOM
     containerState.done?.()
     containerState.done = undefined

--- a/playground/vite/src/views/animate-presence/group-animatepresence.vue
+++ b/playground/vite/src/views/animate-presence/group-animatepresence.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { AnimatePresence, LayoutGroup, Motion, motion } from 'motion-v'
+import { ref } from 'vue'
+
+const open = ref(false)
+
+const toggleOpen = () => open.value = !open.value
+</script>
+
+<template>
+  <div class="container-outer">
+    <LayoutGroup>
+      <motion.div
+        layout
+        class="container"
+        :data-open="open"
+      >
+        <AnimatePresence>
+          <Motion
+            v-if="open"
+            layout
+            :exit="{ opacity: 0, y: 50 }"
+            :initial="{ opacity: 0, x: 50 }"
+            :animate="{ opacity: 1, x: 0 }"
+          >
+            <pre class="text">
+              Some long lines to test
+              Some long lines to test
+              Some long lines to test
+              Some long lines to test
+              Some long lines to test
+              Some long lines to test
+            </pre>
+          </Motion>
+        </AnimatePresence>
+
+        <Motion layout="position">
+          <button @click="toggleOpen">
+            Toggle open
+          </button>
+        </Motion>
+      </motion.div>
+    </LayoutGroup>
+  </div>
+</template>
+
+<style scoped>
+.container-outer {
+  width: 100vw;
+  height: 100vh;
+}
+
+.container {
+  background-color: oklch(0.936 0.032 17.717);
+  width: max-content;
+}
+
+.text {
+  white-space: pre-line;
+}
+</style>

--- a/tests/group-animatepresence.spec.ts
+++ b/tests/group-animatepresence.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('AnimatePresence with LayoutGroup', () => {
+  const url = '/animate-presence/group-animatepresence'
+
+  test('container renders and toggle button works', async ({ page }) => {
+    await page.goto(url)
+
+    const container = page.locator('.container')
+    const button = page.getByRole('button', { name: 'Toggle open' })
+
+    await expect(container).toBeVisible()
+    await expect(button).toBeVisible()
+    // Initially closed
+    await expect(container).toHaveAttribute('data-open', 'false')
+  })
+
+  test('container performs layout animation when children exit', async ({ page }) => {
+    await page.goto(url)
+
+    const button = page.getByRole('button', { name: 'Toggle open' })
+    const container = page.locator('.container')
+
+    // Open and wait for animations to fully settle
+    await button.click()
+    await page.waitForTimeout(800)
+
+    // Record container height when open
+    const openBounds = await container.boundingBox()
+    expect(openBounds).not.toBeNull()
+
+    // Close to trigger exit
+    await button.click()
+
+    // Wait for exit animation to complete and layout animation to start
+    await page.waitForTimeout(500)
+
+    // During the layout animation, the container should have a CSS transform applied
+    // (FLIP technique: element jumps to final size, then reverse transform is animated)
+    const hasMidTransform = await container.evaluate((el) => {
+      const style = window.getComputedStyle(el)
+      const transform = style.transform
+      // During layout animation, transform should not be 'none' or identity
+      return transform !== 'none' && transform !== 'matrix(1, 0, 0, 1, 0, 0)'
+    })
+
+    // The container should have a transform during layout animation
+    expect(hasMidTransform).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Fix AnimatePresence to properly update motion snapshots when exit animations finalize within a LayoutGroup
- Add `group-animatepresence` playground page for testing the fix
- Add E2E test covering the AnimatePresence + LayoutGroup interaction

## Test plan
- [ ] Verify `pnpm test:e2e` passes for `group-animatepresence.spec.ts`
- [ ] Manual testing with `pnpm play` to confirm exit animations work correctly in LayoutGroup

🤖 Generated with [Claude Code](https://claude.com/claude-code)