### PR TITLE
refactor: use isAnimationControls from motion-dom

### DIFF
--- a/packages/motion/src/animation/utils.ts
+++ b/packages/motion/src/animation/utils.ts
@@ -1,9 +1,0 @@
-import type { AnimationControls } from './types'
-
-export function isAnimationControls(v?: unknown): v is AnimationControls {
-  return (
-    v !== null
-    && typeof v === 'object'
-    && typeof (v as AnimationControls).start === 'function'
-  )
-}

--- a/packages/motion/src/features/animation/animation.ts
+++ b/packages/motion/src/features/animation/animation.ts
@@ -1,6 +1,5 @@
-import { isAnimationControls } from '@/animation/utils'
 import { Feature } from '@/features/feature'
-import type { AnimationState } from 'motion-dom'
+import { type AnimationState, isAnimationControls } from 'motion-dom'
 import { createAnimationState } from '@/state/animation-state'
 import type { MotionState } from '@/state/motion-state'
 import { isHidden } from '@/utils/is-hidden'

--- a/packages/motion/src/state/animation-state.ts
+++ b/packages/motion/src/state/animation-state.ts
@@ -5,9 +5,8 @@
  * Adaptations for Vue are marked with "// [Vue]" comments.
  */
 import { shallowCompare } from '@/state/utils'
-import { isAnimationControls } from '@/animation/utils'
 import type { AnimationDefinition, TargetAndTransition, VisualElement, VisualElementAnimationOptions } from 'motion-dom'
-import { animateVisualElement, calcChildStagger, isVariantLabel, resolveVariant } from 'motion-dom'
+import { animateVisualElement, calcChildStagger, isAnimationControls, isVariantLabel, resolveVariant } from 'motion-dom'
 import { getVariantContext } from '@/state/utils/get-variant-context'
 
 // --- Aligned with motion-dom variantPriorityOrder ---

--- a/packages/motion/src/utils/resolve-motion-props.ts
+++ b/packages/motion/src/utils/resolve-motion-props.ts
@@ -16,7 +16,7 @@ export interface MotionContext {
 export function resolveMotionProps(
   props: Options,
   context: MotionContext,
-): Options {
+): Options & { presenceContext: PresenceContext } {
   const { layoutGroup, presenceContext, config } = context
 
   const layoutId = layoutGroup.id && props.layoutId


### PR DESCRIPTION
## Summary
- Remove local `isAnimationControls` utility (`animation/utils.ts`) in favor of the one exported from `motion-dom`, reducing code duplication
- Update imports in `animation.ts` and `animation-state.ts` to use `motion-dom`'s `isAnimationControls`
- Fix `resolveMotionProps` return type to include `presenceContext`

## Test plan
- [ ] Verify build passes (`pnpm build`)
- [ ] Verify existing tests still pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)