### PR TITLE
fix: variant animation not firing after gesture on inherited variants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,9 @@ Motion components are built on top of Framer Motion's core, with Vue-specific ad
    - Uses `useMotionState` composable to initialize and manage state
    - Caches components for performance (separate caches for mini/max feature sets)
    - Main export is `motion` object with `.create()` method for any HTML/SVG tag
+   - `useMotionState` lifecycle order: `onMounted` (mount), `onBeforeUpdate` (beforeUpdate + updateOptions), `onUpdated` (update), `onBeforeUnmount` (beforeUnmount), `onUnmounted` (unmount if disconnected)
+   - Props are updated via `state.updateOptions()` in `onBeforeUpdate` (not `onUpdated`) so parent variant context is available to children during their update cycle
+   - Props merging (layoutId namespacing, transition defaults, presence initial) is handled by `resolveMotionProps` utility (`src/utils/resolve-motion-props.ts`), shared with the `v-motion` directive
 
 2. **Visual Element State** (`packages/motion/src/state/`)
    - Core `MotionState` class manages animation state and lifecycle
@@ -81,6 +84,15 @@ Motion components are built on top of Framer Motion's core, with Vue-specific ad
    - Wraps Vue's `Transition`/`TransitionGroup` components
    - Provides presence context to child motion components
    - Handles popLayout feature to prevent layout shift during exit animations
+
+7. **v-motion Directive** (`packages/motion/src/`)
+   - Full-featured directive alternative to the `<motion>` component — no wrapper element required
+   - Exports: `vMotion` (domMax bundle), `createMotionDirective(bundle?)`, `createPresetDirective(defaults)`, `MotionPlugin`
+   - Supports all animation, gesture, layout, and exit props identical to `<motion>`
+   - **Key limitation**: does not support parent-child variant propagation (no Vue provide/inject context)
+   - Two syntax styles: props syntax (`v-motion :animate="..."`) and binding value syntax (`v-motion="{ animate: ... }"`) — props win on conflict
+   - Preset directives created via `createPresetDirective` can be overridden per-use via binding value
+   - Registered globally via `MotionPlugin` (supports `presets` option) or Nuxt module (`motionV.directives: true`)
 
 ### Build Configuration
 - Uses Vite for building with separate ES (`.mjs`) and CJS (`.js`) outputs

--- a/packages/motion/src/components/motion/use-motion-state.ts
+++ b/packages/motion/src/components/motion/use-motion-state.ts
@@ -147,10 +147,13 @@ export function useMotionState(
 
   onBeforeUpdate(() => {
     state.beforeUpdate()
+    // Update visual element props early (parent fires before children)
+    // so children's animateChanges() sees the latest parent variant context.
+    state.updateOptions(getMotionProps())
   })
 
   onUpdated(() => {
-    state.update(getMotionProps())
+    state.update()
   })
 
   return {

--- a/packages/motion/src/directive/index.ts
+++ b/packages/motion/src/directive/index.ts
@@ -217,11 +217,15 @@ export function createMotionDirective(
       state.updateFeatures()
     },
 
-    beforeUpdate(el) {
+    beforeUpdate(el, binding, vnode) {
       const state = mountedStates.get(el)
       if (!state)
         return
+      const provides = resolveProvides(vnode, binding)
+      const motionProps = mergeMotionProps(vnode, binding.value)
+      const { options } = buildMotionOptions(motionProps, provides, resolveTag(el))
       state.beforeUpdate()
+      state.updateOptions(options)
     },
 
     updated(el, binding, vnode) {
@@ -229,10 +233,7 @@ export function createMotionDirective(
       if (!state)
         return
       cleanVNodeProps(el, vnode.props)
-      const provides = resolveProvides(vnode, binding)
-      const motionProps = mergeMotionProps(vnode, binding.value)
-      const { options } = buildMotionOptions(motionProps, provides, resolveTag(el))
-      state.update(options)
+      state.update()
     },
 
     beforeUnmount(el) {

--- a/packages/motion/src/state/motion-state.ts
+++ b/packages/motion/src/state/motion-state.ts
@@ -136,8 +136,7 @@ export class MotionState {
   }
 
   // Update motion state with new options
-  update(options: Options) {
-    this.updateOptions(options)
+  update() {
     this.updateFeatures()
     this.didUpdate()
   }


### PR DESCRIPTION
## Summary

- Fixes a bug where child motion components with inherited variants would stop animating after a gesture (whileHover/whilePress) was triggered
- Root cause: Vue's `onUpdated` fires children before parents, so children's `animateChanges()` saw stale parent `visualElement.props`, set `protectedKeys` incorrectly, and blocked the parent's subsequent variant propagation via `shouldBlockAnimation`
- Fix: move `updateOptions()` to `onBeforeUpdate` (which fires parent-first) so children always see the latest parent variant context

## Test plan

- [x] Open `/animate-variants` playground page
- [x] Hover over list items to trigger `whileHover` animation
- [x] Toggle the menu open/closed — previously hovered items should now animate correctly
- [x] Verify all existing unit tests pass (`pnpm test`)
- [x] Verify E2E tests pass (`pnpm test:e2e`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)