### PR TITLE
chore: Remove debug console.log 

### DIFF
--- a/packages/motion/src/directive/index.ts
+++ b/packages/motion/src/directive/index.ts
@@ -202,7 +202,6 @@ export function createMotionDirective(
       const provides = resolveProvides(vnode, binding)
       const motionProps = mergeMotionProps(vnode, binding.value)
       const { options, parentState } = buildMotionOptions(motionProps, provides, resolveTag(el))
-      console.log('options', options)
       const state = new MotionState(options, parentState!)
       state.initVisualElement(renderer)
       mountedStates.set(el, state)

--- a/playground/nuxt/nuxt.config.ts
+++ b/playground/nuxt/nuxt.config.ts
@@ -11,6 +11,7 @@ export default defineNuxtConfig({
         'fade-in': {
           initial: { opacity: 0 },
           animate: { opacity: 1 },
+          exit: { opacity: 0 },
           transition: { duration: 0.5 },
         },
         'slide-up': {

--- a/playground/nuxt/pages/preset-directive.vue
+++ b/playground/nuxt/pages/preset-directive.vue
@@ -70,13 +70,15 @@ const show = ref(true)
         {{ show ? 'Hide' : 'Show' }}
       </button>
       <div class="h-28 relative">
-        <div
-          v-if="show"
-          v-fade-in
-          class="w-44 h-24 bg-indigo-500 rounded-xl flex items-center justify-center text-white font-semibold"
-        >
-          Toggle me
-        </div>
+        <AnimatePresence>
+          <div
+            v-show="show"
+            v-fade-in
+            class="w-44 h-24 bg-indigo-500 rounded-xl flex items-center justify-center text-white font-semibold"
+          >
+            Toggle me
+          </div>
+        </AnimatePresence>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Remove debug `console.log` from directive initialization code
- Add `exit` property to the `fade-in` preset configuration in the Nuxt playground
- Update preset directive playground to use `AnimatePresence` with `v-show` instead of `v-if` for proper exit animations

## Test plan
- [x] Verify preset directive exit animations work in the Nuxt playground
- [x] Confirm no regressions in existing directive functionality
- [x] Test fade-in preset toggle shows both enter and exit animations

🤖 Generated with [Claude Code](https://claude.com/claude-code)