### PR TITLE
fix: AnimatePresence custom prop not reaching exit variants with v-if

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,8 @@ Motion components are built on top of Framer Motion's core, with Vue-specific ad
    - Wraps Vue's `Transition`/`TransitionGroup` components
    - Provides presence context to child motion components
    - Handles popLayout feature to prevent layout shift during exit animations
+   - `custom` prop is synced eagerly inside the `exit()` hook (not via a Vue watcher) because Vue's `@leave` fires synchronously during patching — a `flush: 'pre'` watcher is not guaranteed to have run when `v-if` and `custom` change in the same tick
+   - `presenceContext` is passed to `visualElement` both at init (`initVisualElement`) and on updates (`updateOptions`) so exit variant functions receive the correct `custom` value
 
 7. **v-motion Directive** (`packages/motion/src/`)
    - Full-featured directive alternative to the `<motion>` component — no wrapper element required
@@ -150,3 +152,4 @@ Motion components are built on top of Framer Motion's core, with Vue-specific ad
    - If playground doesn't reflect changes, ensure you ran `pnpm build`
    - Plugin builds happen automatically after motion build via `afterBuild` hook
    - Watch mode available with `pnpm dev` for iterative development
+   - If exit variant functions do not receive the `custom` value: ensure `presenceContext` is threaded through `initVisualElement` and `updateOptions` in `MotionState`, and that `custom` is synced eagerly at the start of the `exit()` hook in `usePresenceContainer`

--- a/packages/motion/src/components/__tests__/animate-presence-custom.test.tsx
+++ b/packages/motion/src/components/__tests__/animate-presence-custom.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, nextTick, ref } from 'vue'
+import { AnimatePresence, Motion } from '@/components'
+import { delay } from '@/shared/test'
+
+const globalStubs = {
+  stubs: {
+    Transition: false,
+    TransitionGroup: false,
+  },
+}
+
+describe('animatePresence custom prop with v-if', () => {
+  it('exit variant function receives custom value', async () => {
+    const exitCalls: any[] = []
+
+    const Wrapper = defineComponent({
+      components: { AnimatePresence, Motion },
+      setup() {
+        const show = ref(true)
+        const variants = {
+          visible: { opacity: 1 },
+          hidden: (custom: any) => {
+            exitCalls.push(custom)
+            return { opacity: 0 }
+          },
+        }
+        return { show, variants }
+      },
+      template: `
+        <AnimatePresence :custom="42">
+          <div v-if="show" key="item">
+            <Motion
+              initial="hidden"
+              animate="visible"
+              exit="hidden"
+              :variants="variants"
+              :transition="{ duration: 0.05 }"
+            />
+          </div>
+        </AnimatePresence>
+      `,
+    })
+
+    const wrapper = mount(Wrapper, {
+      attachTo: document.body,
+      global: globalStubs,
+    })
+    await nextTick()
+    await delay(50)
+    exitCalls.length = 0
+
+    wrapper.vm.show = false
+    await nextTick()
+    await delay(100)
+
+    expect(exitCalls.length).toBeGreaterThan(0)
+    expect(exitCalls[0]).toBe(42)
+
+    wrapper.unmount()
+  })
+
+  it('exit variant receives updated custom when changed before v-if toggle', async () => {
+    const exitCalls: any[] = []
+
+    const Wrapper = defineComponent({
+      components: { AnimatePresence, Motion },
+      setup() {
+        const show = ref(true)
+        const custom = ref(1)
+        const variants = {
+          visible: { opacity: 1 },
+          hidden: (c: any) => {
+            exitCalls.push(c)
+            return { opacity: 0 }
+          },
+        }
+        return { show, custom, variants }
+      },
+      template: `
+        <AnimatePresence :custom="custom">
+          <div v-if="show" key="item">
+            <Motion
+              initial="hidden"
+              animate="visible"
+              exit="hidden"
+              :variants="variants"
+              :transition="{ duration: 0.05 }"
+            />
+          </div>
+        </AnimatePresence>
+      `,
+    })
+
+    const wrapper = mount(Wrapper, {
+      attachTo: document.body,
+      global: globalStubs,
+    })
+    await nextTick()
+    await delay(50)
+    exitCalls.length = 0
+
+    wrapper.vm.custom = -1
+    await nextTick()
+
+    wrapper.vm.show = false
+    await nextTick()
+    await delay(100)
+
+    expect(exitCalls.length).toBeGreaterThan(0)
+    expect(exitCalls[0]).toBe(-1)
+
+    wrapper.unmount()
+  })
+})

--- a/packages/motion/src/components/animate-presence/use-presence-container.ts
+++ b/packages/motion/src/components/animate-presence/use-presence-container.ts
@@ -1,4 +1,4 @@
-import { onMounted, onUnmounted, watch } from 'vue'
+import { onMounted, onUnmounted } from 'vue'
 import { mountedStates } from '@/state'
 import { motionGlobalConfig } from '@/config'
 import type { MotionState } from '@/state'
@@ -62,10 +62,6 @@ export function usePresenceContainer(props: AnimatePresenceProps) {
     onMotionExitComplete,
   }
 
-  watch(() => props.custom, (v) => {
-    presenceContext.custom = v
-  }, { flush: 'pre' })
-
   provideAnimatePresence(presenceContext)
 
   onMounted(() => {
@@ -106,6 +102,9 @@ export function usePresenceContainer(props: AnimatePresenceProps) {
   }
 
   function exit(el: Element, done: VoidFunction) {
+    // Sync custom eagerly — the @leave hook fires synchronously during patching.
+    presenceContext.custom = props.custom
+
     const container = el as HTMLElement
     // Discover all motion states inside this container at exit time
     const states = findMotionStates(container)

--- a/packages/motion/src/state/motion-state.ts
+++ b/packages/motion/src/state/motion-state.ts
@@ -102,7 +102,7 @@ export class MotionState {
     this.visualElement?.update({
       ...this.options as any,
       whileTap: this.options.whilePress,
-    }, null as any)
+    }, this.options.presenceContext ?? null)
   }
 
   // Mount motion state to DOM element, handles parent-child relationships
@@ -179,7 +179,7 @@ export class MotionState {
     if (this.visualElement)
       return
     this.visualElement = renderer(this.options.as as string, {
-      presenceContext: null,
+      presenceContext: this.options.presenceContext ?? null,
       parent: this.parent?.visualElement,
       props: { ...this.options, whileTap: this.options.whilePress } as any,
       visualState: {


### PR DESCRIPTION
## Summary

- Fix `presenceContext` always being `null` on `visualElement`, causing exit variant functions to never receive the `custom` value from `AnimatePresence`
- Sync `presenceContext.custom` eagerly in the `exit()` hook instead of relying on a `flush:'pre'` watcher (which hasn't run yet when `@leave` fires synchronously during Vue patching)
- Remove the now-redundant `watch` on `props.custom`

## Test plan

- [x] Added vitest integration tests (`animate-presence-custom.test.tsx`) covering:
  - Exit variant function receives `custom` value from `AnimatePresence`
  - Updated `custom` value is received when `custom` and `v-if` change across ticks
- [x] All existing unit tests pass (73 passed)