### PR TITLE
fix(useTransform): React parity — accelerate propagation + onUnmounted guard

### DIFF
--- a/packages/motion/src/value/__tests__/use-transform.test.tsx
+++ b/packages/motion/src/value/__tests__/use-transform.test.tsx
@@ -41,6 +41,92 @@ describe('useTransform', () => {
     expect(opacity.get()).toBe(1)
   })
 
+  describe('accelerate propagation', () => {
+    it('should propagate accelerate config from input to output for range transform', () => {
+      const x = motionValue(0)
+      const mockAccelerate = {
+        factory: () => ({ stop: () => {} }) as any,
+        times: [0, 1],
+        keyframes: [0, 1],
+        ease: (v: number) => v,
+        duration: 1,
+      }
+      x.accelerate = mockAccelerate
+
+      const opacity = useTransform(x, [0, 1], [0, 1])
+
+      expect(opacity.accelerate).toBeDefined()
+      expect(opacity.accelerate!.times).toEqual([0, 1])
+      expect(opacity.accelerate!.keyframes).toEqual([0, 1])
+      expect(opacity.accelerate!.isTransformed).toBe(true)
+      expect(opacity.accelerate!.factory).toBe(mockAccelerate.factory)
+    })
+
+    it('should not propagate accelerate when transformer is a function', () => {
+      const x = motionValue(0)
+      x.accelerate = {
+        factory: () => ({ stop: () => {} }) as any,
+        times: [0, 1],
+        keyframes: [0, 1],
+        ease: (v: number) => v,
+        duration: 1,
+      }
+
+      const doubled = useTransform(x, (v) => v * 2)
+
+      expect(doubled.accelerate).toBeUndefined()
+    })
+
+    it('should not propagate accelerate when clamp is false', () => {
+      const x = motionValue(0)
+      x.accelerate = {
+        factory: () => ({ stop: () => {} }) as any,
+        times: [0, 1],
+        keyframes: [0, 1],
+        ease: (v: number) => v,
+        duration: 1,
+      }
+
+      const opacity = useTransform(x, [0, 1], [0, 1], { clamp: false })
+
+      expect(opacity.accelerate).toBeUndefined()
+    })
+
+    it('should not propagate accelerate when already transformed', () => {
+      const x = motionValue(0)
+      x.accelerate = {
+        factory: () => ({ stop: () => {} }) as any,
+        times: [0, 1],
+        keyframes: [0, 1],
+        ease: (v: number) => v,
+        duration: 1,
+        isTransformed: true,
+      }
+
+      const opacity = useTransform(x, [0, 1], [0, 1])
+
+      expect(opacity.accelerate).toBeUndefined()
+    })
+
+    it('should use resolved inputRange value when inputRange is a ref', () => {
+      const x = motionValue(0)
+      const mockAccelerate = {
+        factory: () => ({ stop: () => {} }) as any,
+        times: [0, 1],
+        keyframes: [0, 1],
+        ease: (v: number) => v,
+        duration: 1,
+      }
+      x.accelerate = mockAccelerate
+
+      const inputRange = ref([0, 100])
+      const opacity = useTransform(x, inputRange, [0, 1])
+
+      expect(opacity.accelerate).toBeDefined()
+      expect(opacity.accelerate!.times).toEqual([0, 100])
+    })
+  })
+
   describe('multi-output transform', () => {
     it('should transform single input to multiple outputs', () => {
       const x = motionValue(0)

--- a/packages/motion/src/value/use-combine-values.ts
+++ b/packages/motion/src/value/use-combine-values.ts
@@ -1,5 +1,5 @@
 import { type MotionValue, cancelFrame, frame, motionValue } from 'motion-dom'
-import { onUnmounted } from 'vue'
+import { getCurrentInstance, onUnmounted } from 'vue'
 
 export function useCombineMotionValues<T>(
   combineValues: () => T,
@@ -32,9 +32,11 @@ export function useCombineMotionValues<T>(
     cancelFrame(updateValue)
   }
 
-  onUnmounted(() => {
-    unsubscribe()
-  })
+  if (getCurrentInstance()) {
+    onUnmounted(() => {
+      unsubscribe()
+    })
+  }
   return {
     subscribe,
     unsubscribe,

--- a/packages/motion/src/value/use-transform.ts
+++ b/packages/motion/src/value/use-transform.ts
@@ -188,12 +188,40 @@ export function useTransform<I, O>(
     inputValues = Array.isArray(input) ? input : [input]
   }
 
-  return Array.isArray(input)
+  const result = Array.isArray(input)
     ? useListTransform(inputValues, transformer as MultiTransformer<string | number, O>)
     : useListTransform(inputValues, (values) => {
       // Extract only the input value (ignore bridge if present)
       return (transformer as SingleTransformer<I, O>)(values[0] as I)
     })
+
+  // Propagate accelerate config for native scroll timeline support.
+  // When the input is a scroll progress MotionValue with an accelerate config
+  // (set by useScroll), we forward it to the output with updated times/keyframes
+  // so the motion component can use a native scroll timeline for this transform.
+  if (!Array.isArray(input)) {
+    const inputAccelerate = (input as MotionValue<any>).accelerate
+    if (
+      inputAccelerate
+      && !inputAccelerate.isTransformed
+      && typeof inputRangeOrTransformer !== 'function'
+      && Array.isArray(outputRange)
+      && options?.clamp !== false
+    ) {
+      const resolvedInputRange = isRef(inputRangeOrTransformer)
+        ? inputRangeOrTransformer.value
+        : inputRangeOrTransformer
+      result.accelerate = {
+        ...inputAccelerate,
+        times: resolvedInputRange,
+        keyframes: outputRange,
+        isTransformed: true,
+        ...(options?.ease ? { ease: options.ease } : {}),
+      }
+    }
+  }
+
+  return result
 }
 
 function useListTransform<I, O>(


### PR DESCRIPTION
## Summary

- **fix**: Guard `onUnmounted` in `useCombineMotionValues` with `getCurrentInstance()` to prevent Vue warnings when called outside component `setup()` context
- **feat**: Propagate `.accelerate` config from input `MotionValue` to output in `useTransform` range-based path, matching React framer-motion behavior so scroll timeline acceleration works through `useTransform` chains

## Details

### `useCombineMotionValues` — `onUnmounted` guard

`onUnmounted()` was called unconditionally, causing Vue warnings when `useTransform` (or any composable built on `useCombineMotionValues`) is used outside a component (e.g. module-level, plain unit tests). Now wrapped with `getCurrentInstance()` check.

### `useTransform` — `accelerate` propagation

`useScroll` sets `.accelerate` on `scrollXProgress`/`scrollYProgress` to enable native scroll timeline animations. Previously, piping through `useTransform` dropped this config, silently falling back to JS-driven animation.

Now the config is forwarded to the output `MotionValue` with updated `times`/`keyframes` from the transform range. Propagation is skipped when:
- transformer is a function (not range-based)
- `clamp: false` (extrapolation breaks scroll timeline assumptions)
- `accelerate.isTransformed` is already `true` (prevents double-wrapping)

## Test plan

- [x] All existing tests still pass (`pnpm --filter motion-v test`)
- [x] 5 new tests covering accelerate propagation cases (positive + negative)
- [x] No `[Vue warn]: onUnmounted is called when there is no active component instance` warnings in test output