### PR TITLE
fix(useSpring): infer return type from source argument

### DIFF
--- a/packages/motion/src/value/use-spring.ts
+++ b/packages/motion/src/value/use-spring.ts
@@ -27,8 +27,10 @@ export function useFollowValue<T extends AnyResolvedKeyframe>(
   return value
 }
 
+export function useSpring(source: MotionValue<string> | string, config?: MaybeRef<SpringOptions>): MotionValue<string>
+export function useSpring(source: MotionValue<number> | number, config?: MaybeRef<SpringOptions>): MotionValue<number>
 export function useSpring(
-  source: MotionValue<string> | MotionValue<number> | number,
+  source: MotionValue<string> | MotionValue<number> | string | number,
   config: MaybeRef<SpringOptions> = {},
 ) {
   const value = motionValue(


### PR DESCRIPTION
## Summary
- Add overload signatures to `useSpring` so the return type is inferred from the source argument
- `MotionValue<string> | string` → returns `MotionValue<string>`
- `MotionValue<number> | number` → returns `MotionValue<number>`

## Test plan
- [x] Verify TypeScript correctly infers `MotionValue<string>` when passing a string source
- [x] Verify TypeScript correctly infers `MotionValue<number>` when passing a number source