### PR TITLE
fix(motion-state): skip data-ap attribute outside AnimatePresence

### DIFF
--- a/packages/motion/src/state/motion-state.ts
+++ b/packages/motion/src/state/motion-state.ts
@@ -114,7 +114,10 @@ export class MotionState {
     )
     mountedStates.set(element, this)
     this.element = element
-    element.setAttribute(motionGlobalConfig.motionAttribute, this.options.presenceContext?.presenceId ?? '')
+    const presenceId = this.options.presenceContext?.presenceId
+    if (presenceId !== undefined) {
+      element.setAttribute(motionGlobalConfig.motionAttribute, presenceId)
+    }
     this.visualElement?.mount(element)
     this.updateFeatures()
   }


### PR DESCRIPTION
## Summary
- Only set \`motionGlobalConfig.motionAttribute\` (\`data-ap\`) on mount when the element is actually participating in an \`AnimatePresence\` (i.e. \`presenceContext.presenceId\` is defined).
- Avoids rendering an empty \`data-ap=\"\"\` on every motion element outside \`AnimatePresence\`, keeping the DOM cleaner with no functional change.

## Why it's safe
- \`motionGlobalConfig.motionAttribute\` is only read in \`use-presence-container.ts\` via exact \`=== presenceId\` / \`[attr=\"presenceId\"]\` matches — an empty string never matched anything, so removing it is inert.
- Vue's \`provide\`/\`inject\` fixes the presence context at setup time; there is no "wrapped into AnimatePresence later" scenario that would need a retroactive attribute write.

## Test plan
- [x] \`pnpm --filter motion-v test\` — 114 passed / 1 skipped
- [x] \`pnpm test:e2e\` (animate-presence / pop-layout suites) in CI
- [x] Manual: confirm motion elements outside \`AnimatePresence\` no longer carry \`data-ap\`, and elements inside still carry \`data-ap=\"<presenceId>\"\` with working enter/exit animations