### PR TITLE
Fix skipped useAnimate animations

### DIFF
--- a/packages/motion/src/animation/hooks/use-animate.ts
+++ b/packages/motion/src/animation/hooks/use-animate.ts
@@ -2,6 +2,8 @@ import type { AnimationPlaybackControls, AnimationScope } from 'motion-dom'
 import type { Ref, UnwrapRef } from 'vue'
 import { onUnmounted, ref } from 'vue'
 import { createScopedAnimate } from 'framer-motion/dom'
+import { MotionGlobalConfig } from 'motion-utils'
+import { useMotionConfig } from '@/components/motion-config'
 
 type Scope = Ref<UnwrapRef<Element>> & { animations: AnimationPlaybackControls[] }
 export function useAnimate<T extends Element = any>(): [Scope, ReturnType<typeof createScopedAnimate>] {
@@ -26,7 +28,24 @@ export function useAnimate<T extends Element = any>(): [Scope, ReturnType<typeof
 
   domProxy.animations = []
 
-  const animate = createScopedAnimate({ scope: domProxy as unknown as AnimationScope<T> })
+  const config = useMotionConfig()
+  const scopedAnimate = createScopedAnimate({
+    scope: domProxy as unknown as AnimationScope<T>,
+  })
+
+  const animate = ((...args: Parameters<typeof scopedAnimate>) => {
+    if (!config.value.skipAnimations)
+      return scopedAnimate(...args)
+
+    const previousSkipAnimations = MotionGlobalConfig.skipAnimations
+    MotionGlobalConfig.skipAnimations = true
+    try {
+      return scopedAnimate(...args)
+    }
+    finally {
+      MotionGlobalConfig.skipAnimations = previousSkipAnimations
+    }
+  }) as typeof scopedAnimate
 
   onUnmounted(() => {
     domProxy.animations.forEach(animation => animation.stop())

--- a/packages/motion/src/components/__tests__/motion-config.test.tsx
+++ b/packages/motion/src/components/__tests__/motion-config.test.tsx
@@ -1,9 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { motionValue } from 'framer-motion/dom'
-import { defineComponent, nextTick } from 'vue'
+import { defineComponent, nextTick, onMounted } from 'vue'
 import MotionConfig from '@/components/motion-config/MotionConfig.vue'
 import { Motion } from '@/components/motion'
+import { useAnimate } from '@/animation'
 
 describe('reducedMotion', () => {
   it('reducedMotion always', async () => {
@@ -20,5 +21,39 @@ describe('reducedMotion', () => {
     await nextTick()
     await new Promise(resolve => setTimeout(resolve, 20))
     expect(scale.get()).toBe(0.5)
+  })
+})
+
+describe('skipAnimations', () => {
+  it('applies final useAnimate value instantly without tracking an animation', async () => {
+    let getScopeAnimations = () => 0
+    const Child = defineComponent({
+      setup() {
+        const [scope, animate] = useAnimate<HTMLDivElement>()
+        getScopeAnimations = () => scope.animations.length
+
+        onMounted(() => {
+          animate(scope.value, { opacity: 0.5 }, { duration: 10 })
+        })
+
+        return () => <div ref={scope} style={{ opacity: 1 }} />
+      },
+    })
+
+    const wrapper = mount(defineComponent({
+      setup() {
+        return () => (
+          <MotionConfig skipAnimations>
+            <Child />
+          </MotionConfig>
+        )
+      },
+    }))
+
+    await nextTick()
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    expect(wrapper.find('div').element.style.opacity).toBe('0.5')
+    expect(getScopeAnimations()).toBe(0)
   })
 })

--- a/packages/motion/src/components/motion-config/MotionConfig.vue
+++ b/packages/motion/src/components/motion-config/MotionConfig.vue
@@ -24,6 +24,7 @@ const parentConfig = useMotionConfig()
 const config = computed(() => ({
   transition: props.transition ?? parentConfig.value.transition,
   reducedMotion: props.reducedMotion ?? parentConfig.value.reducedMotion,
+  skipAnimations: props.skipAnimations ?? parentConfig.value.skipAnimations,
   nonce: props.nonce ?? parentConfig.value.nonce,
   inViewOptions: props.inViewOptions ?? parentConfig.value.inViewOptions,
 }))

--- a/packages/motion/src/components/motion-config/context.ts
+++ b/packages/motion/src/components/motion-config/context.ts
@@ -7,6 +7,7 @@ import { type ComputedRef, computed } from 'vue'
  */
 export const defaultConfig: MotionConfigState = {
   reducedMotion: 'never',
+  skipAnimations: false,
   transition: undefined,
   nonce: undefined,
 }

--- a/packages/motion/src/components/motion-config/types.ts
+++ b/packages/motion/src/components/motion-config/types.ts
@@ -12,6 +12,8 @@ export interface MotionConfigState {
   reduceMotion?: 'user' | 'never' | 'always'
   /** Controls motion reduction based on user preference or explicit setting */
   reducedMotion?: 'user' | 'never' | 'always'
+  /** Skips animations and applies final values instantly */
+  skipAnimations?: boolean
   /** Custom nonce for CSP compliance with inline styles */
   nonce?: string
   /** Options for the inView prop */

--- a/packages/motion/src/state/motion-state.ts
+++ b/packages/motion/src/state/motion-state.ts
@@ -198,6 +198,7 @@ export class MotionState {
         latestValues: { ...this.latestValues } as any,
       },
       reducedMotionConfig: this.options.motionConfig?.reducedMotion,
+      skipAnimations: this.options.motionConfig?.skipAnimations,
     })
     this.visualElement.parent?.addChild(this.visualElement)
     if (this.isMounted()) {

--- a/playground/vite/src/views/use-animate-skip-animations.vue
+++ b/playground/vite/src/views/use-animate-skip-animations.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { defineComponent, h, onMounted } from 'vue'
+import { MotionConfig, useAnimate } from 'motion-v'
+
+const UseAnimateTarget = defineComponent({
+  setup() {
+    const [scope, animate] = useAnimate<HTMLDivElement>()
+
+    onMounted(() => {
+      animate(scope.value, { opacity: 0.5 }, { duration: 10 })
+    })
+
+    return () => h('div', {
+      'ref': scope,
+      'data-testid': 'skip-animations-target',
+      'style': { opacity: 1 },
+    })
+  },
+})
+</script>
+
+<template>
+  <MotionConfig skip-animations>
+    <UseAnimateTarget />
+  </MotionConfig>
+</template>

--- a/tests/use-animate-skip-animations.spec.ts
+++ b/tests/use-animate-skip-animations.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('useAnimate with MotionConfig skipAnimations', () => {
+  test('applies final value instantly without active browser animations', async ({ page }) => {
+    await page.goto('/use-animate-skip-animations')
+
+    const target = page.locator('[data-testid="skip-animations-target"]')
+    await page.waitForTimeout(50)
+
+    expect(await target.evaluate(el => window.getComputedStyle(el).opacity)).toBe('0.5')
+    expect(await target.evaluate(el => el.getAnimations().length)).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

- Add skipAnimations to Vue MotionConfig state and inheritance.
- Thread skipAnimations into declarative visual element creation.
- Make useAnimate respect MotionConfig skipAnimations via Motion's instant skip path.
- Add unit and Playwright coverage.

## Root Cause

Vue MotionConfig did not expose skipAnimations, and useAnimate created scoped animations without reading MotionConfig.

## Validation

- pnpm --filter motion-v test -- --run
- pnpm build
- pnpm exec playwright test tests/use-animate-skip-animations.spec.ts --project=chromium --project=webkit

## Not Tested

- pnpm --filter @motion-vue/playground-vite build because vue-tsc is unavailable in that package context.