### PR TITLE
chore(deps): update framer-motion to ^12.40.0

### DIFF
--- a/packages/motion/package.json
+++ b/packages/motion/package.json
@@ -63,9 +63,9 @@
     "vue": ">=3.0.0"
   },
   "dependencies": {
-    "framer-motion": "^12.38.0",
+    "framer-motion": "^12.40.0",
     "hey-listen": "^1.0.8",
-    "motion-dom": "^12.38.0",
-    "motion-utils": "^12.36.0"
+    "motion-dom": "^12.40.0",
+    "motion-utils": "^12.39.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,17 +91,17 @@ importers:
         specifier: '>=10.0.0'
         version: 12.7.0(typescript@5.9.2)
       framer-motion:
-        specifier: ^12.38.0
-        version: 12.38.0
+        specifier: ^12.40.0
+        version: 12.40.0
       hey-listen:
         specifier: ^1.0.8
         version: 1.0.8
       motion-dom:
-        specifier: ^12.38.0
-        version: 12.38.0
+        specifier: ^12.40.0
+        version: 12.40.0
       motion-utils:
-        specifier: ^12.36.0
-        version: 12.36.0
+        specifier: ^12.39.0
+        version: 12.39.0
       vue:
         specifier: '>=3.0.0'
         version: 3.5.17(typescript@5.9.2)
@@ -4546,8 +4546,8 @@ packages:
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
-  framer-motion@12.38.0:
-    resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
+  framer-motion@12.40.0:
+    resolution: {integrity: sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
@@ -5826,8 +5826,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  motion-dom@12.38.0:
-    resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
+  motion-dom@12.40.0:
+    resolution: {integrity: sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==}
 
   motion-number-vue@1.0.5:
     resolution: {integrity: sha512-Cc4jX6ZNhwXDVVbqOu6MIDXOLnP7PmqkQHkRK/OL+kcHfASXfssorbiiZ46lff+NaJO5LVlNVkIldLNTWAEPFw==}
@@ -5840,8 +5840,8 @@ packages:
       motion-v: '>=0.11.0-beta.5'
       vue: '>=3.0.0'
 
-  motion-utils@12.36.0:
-    resolution: {integrity: sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==}
+  motion-utils@12.39.0:
+    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -13392,10 +13392,10 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
-  framer-motion@12.38.0:
+  framer-motion@12.40.0:
     dependencies:
-      motion-dom: 12.38.0
-      motion-utils: 12.36.0
+      motion-dom: 12.40.0
+      motion-utils: 12.39.0
       tslib: 2.8.1
 
   fresh@0.5.2: {}
@@ -14683,9 +14683,9 @@ snapshots:
       ast-module-types: 6.0.1
       node-source-walk: 7.0.1
 
-  motion-dom@12.38.0:
+  motion-dom@12.40.0:
     dependencies:
-      motion-utils: 12.36.0
+      motion-utils: 12.39.0
 
   motion-number-vue@1.0.5(vue@3.5.30(typescript@5.9.2)):
     dependencies:
@@ -14701,7 +14701,7 @@ snapshots:
       motion-v: link:packages/motion
       vue: 3.5.30(typescript@5.9.2)
 
-  motion-utils@12.36.0: {}
+  motion-utils@12.39.0: {}
 
   mri@1.2.0: {}
 


### PR DESCRIPTION
## Summary
- Bump `framer-motion` and `motion-dom` to `^12.40.0`
- Bump `motion-utils` to `^12.39.0`
- Refresh `pnpm-lock.yaml` accordingly

## Test plan
- ✅ `pnpm --filter motion-v build` succeeds
- ✅ `pnpm --filter motion-v test` — 114 passed, 1 skipped