### PR TITLE
fix(useAnimate): respect MotionConfig skipAnimations

### DIFF
--- a/packages/motion/src/animation/hooks/__tests__/use-animate.test.tsx
+++ b/packages/motion/src/animation/hooks/__tests__/use-animate.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { motionValue } from 'framer-motion/dom'
+import { h, nextTick } from 'vue'
+import { MotionConfig } from '@/components/motion-config'
+import { useAnimate } from '../use-animate'
+import { delay } from '@/shared/test'
+
+describe('useAnimate skipAnimations', () => {
+  function mountWithConfig(configProps: Record<string, unknown>) {
+    let animate: ReturnType<typeof useAnimate>[1]
+    const Child = {
+      setup() {
+        const [, a] = useAnimate()
+        animate = a
+        return () => h('div')
+      },
+    }
+    mount({
+      components: { MotionConfig, Child },
+      setup() {
+        return { configProps }
+      },
+      render() {
+        return h(MotionConfig, configProps, () => h(Child))
+      },
+    })
+    return () => animate
+  }
+
+  it('applies final value instantly when MotionConfig skipAnimations is set', async () => {
+    const getAnimate = mountWithConfig({ skipAnimations: true })
+    await nextTick()
+
+    const value = motionValue(0)
+    getAnimate()(value, 100, { duration: 10 })
+    await delay(50)
+
+    expect(value.get()).toBe(100)
+  })
+
+  it('animates over time when skipAnimations is not set', async () => {
+    const getAnimate = mountWithConfig({})
+    await nextTick()
+
+    const value = motionValue(0)
+    getAnimate()(value, 100, { duration: 10 })
+    await delay(50)
+
+    expect(value.get()).toBeLessThan(100)
+  })
+})

--- a/packages/motion/src/animation/hooks/use-animate.ts
+++ b/packages/motion/src/animation/hooks/use-animate.ts
@@ -1,7 +1,8 @@
 import type { AnimationPlaybackControls, AnimationScope } from 'motion-dom'
 import type { Ref, UnwrapRef } from 'vue'
-import { onUnmounted, ref } from 'vue'
+import { computed, onUnmounted, ref } from 'vue'
 import { createScopedAnimate } from 'framer-motion/dom'
+import { useMotionConfig } from '@/components/motion-config'
 
 type Scope = Ref<UnwrapRef<Element>> & { animations: AnimationPlaybackControls[] }
 export function useAnimate<T extends Element = any>(): [Scope, ReturnType<typeof createScopedAnimate>] {
@@ -26,7 +27,19 @@ export function useAnimate<T extends Element = any>(): [Scope, ReturnType<typeof
 
   domProxy.animations = []
 
-  const animate = createScopedAnimate({ scope: domProxy as unknown as AnimationScope<T> })
+  const config = useMotionConfig()
+
+  // Recreate the scoped animate whenever `skipAnimations` changes so imperative
+  // animations respect `<MotionConfig skip-animations>`, mirroring React's useAnimate.
+  const scopedAnimate = computed(() => createScopedAnimate({
+    scope: domProxy as unknown as AnimationScope<T>,
+    skipAnimations: config.value.skipAnimations,
+  }))
+
+  // Stable wrapper so callers keep a single reference while always delegating to
+  // the latest config-aware scoped animate.
+  const animate = ((...args: Parameters<ReturnType<typeof createScopedAnimate>>) =>
+    scopedAnimate.value(...args)) as ReturnType<typeof createScopedAnimate>
 
   onUnmounted(() => {
     domProxy.animations.forEach(animation => animation.stop())

--- a/packages/motion/src/components/motion-config/MotionConfig.vue
+++ b/packages/motion/src/components/motion-config/MotionConfig.vue
@@ -24,6 +24,7 @@ const parentConfig = useMotionConfig()
 const config = computed(() => ({
   transition: props.transition ?? parentConfig.value.transition,
   reducedMotion: props.reducedMotion ?? parentConfig.value.reducedMotion,
+  skipAnimations: props.skipAnimations ?? parentConfig.value.skipAnimations,
   nonce: props.nonce ?? parentConfig.value.nonce,
   inViewOptions: props.inViewOptions ?? parentConfig.value.inViewOptions,
 }))

--- a/packages/motion/src/components/motion-config/types.ts
+++ b/packages/motion/src/components/motion-config/types.ts
@@ -12,6 +12,8 @@ export interface MotionConfigState {
   reduceMotion?: 'user' | 'never' | 'always'
   /** Controls motion reduction based on user preference or explicit setting */
   reducedMotion?: 'user' | 'never' | 'always'
+  /** Skip all animations in this subtree, applying final values instantly */
+  skipAnimations?: boolean
   /** Custom nonce for CSP compliance with inline styles */
   nonce?: string
   /** Options for the inView prop */


### PR DESCRIPTION
## Summary

Ports the fix from [motiondivision/motion#3683](https://github.com/motiondivision/motion/pull/3683) to motion-vue.

The imperative `animate()` returned by `useAnimate` ignored `<MotionConfig skip-animations>`, so WAAPI animations were still created in subtrees explicitly opted out of motion. In motion-vue this was worse: `MotionConfig` did not expose `skipAnimations` at all.

The underlying `framer-motion@12.40.0` pipeline already supports `skipAnimations` (`createScopedAnimate({ scope, skipAnimations })` → instant final-value application). The gap was entirely in the Vue wrapper layer.

## Changes

- **`motion-config/types.ts`** — add `skipAnimations?: boolean` to `MotionConfigState`
- **`MotionConfig.vue`** — thread `skipAnimations` through config context (`props ?? parentConfig`)
- **`use-animate.ts`** — read `skipAnimations` from `useMotionConfig()` and pass it to `createScopedAnimate`, recreating the scoped animate reactively when the flag changes (mirrors React's `useMemo([scope, skipAnimations])`); a stable wrapper keeps the returned `animate` reference constant

## Test plan

- New `__tests__/use-animate.test.tsx`: with `skipAnimations` set, `animate(value, 100, { duration: 10 })` applies the final value instantly; control case without the flag still animates over time
- Full unit suite: 116 passed / 1 skipped
- `pnpm build` (incl. dts) passes; ESLint clean on changed files