### PR TITLE
feat(arc): support transition.path = arc()

### DIFF
--- a/packages/motion/src/components/__tests__/arc.test.ts
+++ b/packages/motion/src/components/__tests__/arc.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render } from '@testing-library/vue'
+import { nextTick } from 'vue'
+import type { ArcOptions, MotionPath } from 'motion-dom'
+import { Motion } from '@/components'
+import { arc } from '@/index'
+import { delay } from '@/shared/test'
+
+/**
+ * Samples a curve through the public `arc().interpolateProjection()` hook.
+ *
+ * Mirrors motion's internal `createArcPath()` unit tests
+ * (packages/motion-dom/src/animation/utils/__tests__/arc.test.ts), but
+ * `createArcPath` is private — only `arc()` is exported. `interpolateProjection`
+ * samples `from = {fromX, fromY}` to the layout origin `{0, 0}`, so a chord
+ * "travelling right" is expressed as an element currently offset to the left
+ * (`fromX < 0`) moving back to 0.
+ */
+function project(opts: ArcOptions, fromX: number, fromY: number) {
+  const delta = { x: { translate: fromX }, y: { translate: fromY } } as any
+  return arc(opts).interpolateProjection(delta)
+}
+
+describe('arc() interpolateProjection geometry', () => {
+  it('returns the from point at t=0 and the layout origin at t=1', () => {
+    const interp = project({ strength: 1 }, -200, 0)!
+    expect(interp(0).x).toBeCloseTo(-200)
+    expect(interp(0).y).toBeCloseTo(0)
+    expect(interp(1).x).toBeCloseTo(0)
+    expect(interp(1).y).toBeCloseTo(0)
+  })
+
+  it('strength=1 horizontal bulges perpendicular by ~half travel at t=0.5', () => {
+    // 200px chord, strength 1 → bezier midpoint perpendicular offset ~100px.
+    const mid = project({ strength: 1 }, -200, 0)!(0.5)
+    expect(mid.x).toBeCloseTo(-100)
+    expect(Math.abs(mid.y)).toBeCloseTo(100)
+  })
+
+  it('strength=0 produces a straight line at the midpoint', () => {
+    const mid = project({ strength: 0 }, -200, 100)!(0.5)
+    expect(mid.x).toBeCloseTo(-100)
+    expect(mid.y).toBeCloseTo(50)
+  })
+
+  it('default strength (no options) produces a curve', () => {
+    const mid = project({}, -200, 0)!(0.5)
+    expect(Math.abs(mid.y)).toBeGreaterThan(0)
+  })
+
+  it('direction="cw" bulges the opposite side from "ccw"', () => {
+    const cw = project({ strength: 1, direction: 'cw' }, -200, 0)!(0.5)
+    const ccw = project({ strength: 1, direction: 'ccw' }, -200, 0)!(0.5)
+    expect(Math.sign(cw.y)).toBe(-Math.sign(ccw.y))
+  })
+
+  it('auto direction bulges the same screen side across a clean reversal', () => {
+    // Travelling right (offset left → 0) and left (offset right → 0) should
+    // both bulge to the same screen-y side.
+    const right = project({ strength: 1 }, -200, 0)!(0.5)
+    const left = project({ strength: 1 }, 200, 0)!(0.5)
+    expect(Math.sign(right.y)).toBe(Math.sign(left.y))
+  })
+
+  it('peak shifts the apex along the chord', () => {
+    const early = project({ strength: 1, peak: 0.2 }, -200, 0)!(0.5)
+    const late = project({ strength: 1, peak: 0.8 }, -200, 0)!(0.5)
+    expect(early.x).toBeLessThan(late.x)
+  })
+
+  it('rotate false omits rotate', () => {
+    expect(project({ strength: 1 }, -200, 0)!(0.5).rotate).toBeUndefined()
+  })
+
+  it('rotate true returns rotation normalized to 0 at the endpoints', () => {
+    const interp = project({ strength: 1, rotate: true }, -200, 0)!
+    expect(interp(0.5).rotate).toBeDefined()
+    expect(interp(0).rotate).toBeCloseTo(0)
+    expect(interp(1).rotate).toBeCloseTo(0)
+  })
+
+  it('rotate number scales rotation intensity', () => {
+    const full = project({ strength: 1, rotate: 1 }, -200, 0)!(0.25)
+    const half = project({ strength: 1, rotate: 0.5 }, -200, 0)!(0.25)
+    expect(Math.abs(half.rotate!)).toBeCloseTo(Math.abs(full.rotate!) * 0.5)
+  })
+
+  it('does not arc for movements below the 20px minimum distance', () => {
+    // 10px shift is under the layout floor → no interpolator, falls back to
+    // the default straight-line projection.
+    expect(arc({ strength: 1 }).interpolateProjection(
+      { x: { translate: -10 }, y: { translate: 0 } } as any,
+    )).toBeUndefined()
+  })
+})
+
+describe('transition.path integration', () => {
+  it('exports arc() returning a MotionPath with both hooks', () => {
+    const path = arc()
+    expect(typeof path.animateVisualElement).toBe('function')
+    expect(typeof path.interpolateProjection).toBe('function')
+  })
+
+  it('routes transition.path into the keyframe pipeline (path hook is invoked)', async () => {
+    const animateVisualElement = vi.fn()
+    // A spy path: proves motion-v threads `transition.path` through to
+    // motion-dom's animateTarget, which invokes the keyframe hook.
+    const spyPath: MotionPath = {
+      animateVisualElement,
+      interpolateProjection: () => undefined,
+    }
+
+    render(Motion, {
+      props: {
+        animate: { x: 200, y: 100 },
+        transition: { path: spyPath, duration: 0 },
+      },
+      attrs: { 'data-testid': 'motion' },
+    })
+    await nextTick()
+    await delay(30)
+
+    expect(animateVisualElement).toHaveBeenCalled()
+    // target passed to the hook should carry the x/y the path will claim
+    const target = animateVisualElement.mock.calls[0][1]
+    expect(target).toMatchObject({ x: 200, y: 100 })
+  })
+
+  it('real arc() drives x/y to the target on completion', async () => {
+    const wrapper = render(Motion, {
+      props: {
+        animate: { x: 200, y: 100 },
+        transition: { path: arc(), duration: 0 },
+      },
+      attrs: { 'data-testid': 'motion' },
+    })
+    await nextTick()
+    await delay(60)
+
+    const el = wrapper.getByTestId('motion')
+    // x/y are applied as translate transforms; on complete they settle on the
+    // target (200, 100) regardless of the curved mid-path.
+    expect(el.style.transform).toContain('200')
+    expect(el.style.transform).toContain('100')
+  })
+})

--- a/packages/motion/src/index.ts
+++ b/packages/motion/src/index.ts
@@ -1,5 +1,5 @@
 export * from 'framer-motion/dom'
-export { delay as delayInMs, addScaleCorrector, attachFollow, attachSpring } from 'motion-dom'
+export { delay as delayInMs } from 'motion-dom'
 export { motionValue as useMotionValue } from 'motion-dom'
 export * from './components'
 export { default as LayoutGroup } from './components/LayoutGroup.vue'

--- a/packages/motion/src/types/state.ts
+++ b/packages/motion/src/types/state.ts
@@ -1,4 +1,4 @@
-import type { DOMKeyframesDefinition, LegacyAnimationControls, MotionValue, ResolvedValues, TransformProperties, VariantLabels } from 'motion-dom'
+import type { DOMKeyframesDefinition, LegacyAnimationControls, MotionPath, MotionValue, ResolvedValues, TransformProperties, VariantLabels } from 'motion-dom'
 import type { animate } from 'framer-motion/dom'
 import type { LayoutOptions } from '@/features/layout/types'
 import type { DragProps } from '@/features/gestures/drag/types'
@@ -32,6 +32,18 @@ export interface DragOptions {
 }
 
 type TransformPropertiesWithoutTransition = Omit<TransformProperties, 'transition'>
+
+/**
+ * In motion-dom's `Transition` union, the `path` key carries two meanings:
+ * the curved-motion factory (`arc()`, typed `MotionPath`) and the SVG `path`
+ * attribute's per-value transition (typed `ValueTransition`, and non-optional
+ * in the mapped `SVGPathTransitions`). That collision can obscure the
+ * `MotionPath` type at call sites like `transition: { path: arc() }`.
+ *
+ * This distributive override pins `path` to `MotionPath` on every union member
+ * while preserving each member's other fields, so `arc()` is accepted cleanly.
+ */
+type WithMotionPath<T> = T extends any ? Omit<T, 'path'> & { path?: MotionPath } : never
 export type MotionStyleProps = Partial<{
   [K in keyof Omit<VariantType & TransformPropertiesWithoutTransition, 'attrX' | 'attrY' | 'attrScale'>]: string | number | undefined | MotionValue
 }>
@@ -54,8 +66,8 @@ export interface Options<T = any> extends
     transform: TransformProperties,
     generatedTransform: string
   ) => string
-  transition?: $Transition & {
-    layout?: $Transition
+  transition?: WithMotionPath<$Transition> & {
+    layout?: WithMotionPath<$Transition>
   }
   layoutGroup?: LayoutGroupState
   motionConfig?: MotionConfigState

--- a/playground/vite/src/views/transition-arc.vue
+++ b/playground/vite/src/views/transition-arc.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+// Use local alias for dev, not 'motion-vue'
+import { arc, motion } from 'motion-v'
+
+// Create the arc paths once at setup so their direction-continuity closure
+// survives re-renders. NEVER inline `arc()` in the template — a fresh path
+// on every render is amnesiac and loses the stable-screen-side behaviour.
+const pingPongPath = arc({ strength: 0.5 })
+const rotatePath = arc({ strength: 0.6, rotate: true })
+const axisPath = arc({ strength: 0.5 })
+const layoutPath = arc({ strength: 1, rotate: true })
+
+// ping-pong: toggle between two corners, arc auto-picks a stable screen side
+const pinged = ref(false)
+const pingPong = () => (pinged.value = !pinged.value)
+
+// axis-change: alternate a horizontal-dominant and a vertical-dominant move;
+// the continuity closure keeps the bulge on the same screen side.
+const axisStep = ref(0)
+const axisTargets = [
+  { x: 0, y: 0 },
+  { x: 220, y: 0 }, // horizontal dominant
+  { x: 220, y: 160 }, // vertical dominant
+  { x: 0, y: 160 }, // horizontal dominant
+]
+const nextAxis = () => (axisStep.value = (axisStep.value + 1) % axisTargets.length)
+
+// layout arc: shared-element move along a curve
+const layoutLeft = ref(true)
+const swapLayout = () => (layoutLeft.value = !layoutLeft.value)
+</script>
+
+<template>
+  <div style="padding: 40px; display: flex; flex-direction: column; gap: 48px">
+    <!-- 1. keyframe ping-pong -->
+    <section>
+      <h3>① keyframe arc — ping-pong</h3>
+      <button
+        data-testid="ping-btn"
+        @click="pingPong"
+      >
+        Toggle
+      </button>
+      <div style="position: relative; height: 200px; margin-top: 16px">
+        <motion.div
+          data-testid="ping-box"
+          :animate="pinged ? { x: 260, y: 120 } : { x: 0, y: 0 }"
+          :transition="{ path: pingPongPath, duration: 1 }"
+          style="width: 48px; height: 48px; background: #ff7b9c; border-radius: 8px"
+        />
+      </div>
+    </section>
+
+    <!-- 2. keyframe with tangent rotation -->
+    <section>
+      <h3>② keyframe arc — rotate (orient to path)</h3>
+      <button
+        data-testid="rotate-btn"
+        @click="pingPong"
+      >
+        Toggle
+      </button>
+      <div style="position: relative; height: 200px; margin-top: 16px">
+        <motion.div
+          data-testid="rotate-box"
+          :animate="pinged ? { x: 260, y: 120 } : { x: 0, y: 0 }"
+          :transition="{ path: rotatePath, duration: 1 }"
+          style="width: 60px; height: 24px; background: #79c0ff; border-radius: 4px"
+        />
+      </div>
+    </section>
+
+    <!-- 3. axis-change continuity -->
+    <section>
+      <h3>③ keyframe arc — axis-change continuity</h3>
+      <button
+        data-testid="axis-btn"
+        @click="nextAxis"
+      >
+        Next ({{ axisStep }})
+      </button>
+      <div style="position: relative; height: 240px; margin-top: 16px">
+        <motion.div
+          data-testid="axis-box"
+          :animate="axisTargets[axisStep]"
+          :transition="{ path: axisPath, duration: 0.8 }"
+          style="width: 40px; height: 40px; background: #7ee787; border-radius: 8px"
+        />
+      </div>
+    </section>
+
+    <!-- 4. layout arc -->
+    <section>
+      <h3>④ layout arc — shared element along a curve</h3>
+      <button
+        data-testid="layout-btn"
+        @click="swapLayout"
+      >
+        Swap
+      </button>
+      <div
+        style="display: flex; justify-content: space-between; margin-top: 16px; height: 120px"
+      >
+        <div style="width: 80px; display: flex; align-items: flex-start">
+          <motion.div
+            v-if="layoutLeft"
+            data-testid="layout-box"
+            layout-id="arc-shared"
+            :transition="{ layout: { path: layoutPath, duration: 1 } }"
+            style="width: 56px; height: 56px; background: #ffb86c; border-radius: 10px"
+          />
+        </div>
+        <div style="width: 80px; display: flex; align-items: flex-end; justify-content: flex-end">
+          <motion.div
+            v-if="!layoutLeft"
+            data-testid="layout-box"
+            layout-id="arc-shared"
+            :transition="{ layout: { path: layoutPath, duration: 1 } }"
+            style="width: 56px; height: 56px; background: #ffb86c; border-radius: 10px"
+          />
+        </div>
+      </div>
+    </section>
+  </div>
+</template>


### PR DESCRIPTION
## Summary

Adds first-class support for motion's new curved-motion `arc()` (motion [#3699](https://github.com/motiondivision/motion/pull/3699)) in motion-v, usable via `transition.path` for keyframe animations and `transition.layout.path` for layout animations.

```vue
<script setup>
import { motion, arc } from 'motion-v'
// create once at setup so the direction-continuity closure survives re-renders
const path = arc({ strength: 0.6, rotate: true })
</script>

<template>
  <motion.div :animate="{ x: 200, y: 100 }" :transition="{ path }" />
</template>
```

## What's in here

- **No runtime changes needed.** `arc()` ships in the already-depended `motion-dom@^12.40.0` and reaches users through `export * from 'framer-motion/dom'`. The three integration points (keyframe `animateVisualElement`, layout `HTMLProjectionNode`, transform `buildHTMLStyles`) all live in motion-dom, which motion-v reuses wholesale. The redundant explicit `motion-dom` re-exports (`addScaleCorrector`, `attachFollow`, `attachSpring`) are removed since the wildcard already covers them.
- **Type fix for `transition.path`.** motion-dom's `Transition` union overloads the `path` key — `MotionPath` (`arc()`) vs the SVG `path` attribute's `ValueTransition` (non-optional in `SVGPathTransitions`). The collision obscured the `MotionPath` type at `transition: { path: arc() }` call sites. A distributive `WithMotionPath<T>` override pins `path` to `MotionPath` on every union member while preserving each member's other fields.
- **Playground:** `playground/vite/src/views/transition-arc.vue` — `ping-pong`, tangent `rotate`, `axis-change` continuity, and a layout-arc shared element. Demonstrates the create-once reuse pattern.
- **Tests:** `arc.test.ts` mirrors motion's `arc.test.ts` geometry coverage through the public `arc().interpolateProjection()` hook (`createArcPath` is internal-only), plus keyframe-pipeline integration. 14 tests.

## Test plan

- [x] `pnpm --filter motion-v build` — clean
- [x] `pnpm --filter motion-v test` — 130 passed, 1 skipped (no regressions)
- [x] Type probe: `{ path: arc(), duration: 1 }`, `{ layout: { path: arc() } }`, and `MotionProps` all accept `MotionPath`; string `path` is now correctly rejected
- [x] Visual review of `/transition-arc` playground variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)