### PR TITLE
feat(reorder): port multidimensional reorder from framer-motion 13.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,6 @@ Motion for Vue is a Vue.js port of Framer Motion, providing declarative animatio
 - `pnpm test:e2e` - Run Playwright end-to-end tests
 - `pnpm play` - Start the Nuxt playground for interactive testing
 
-### Documentation
-- `pnpm docs:dev` - Start documentation development server
-- `pnpm docs:build` - Build documentation site
-
 ### Testing
 - Single test: `pnpm --filter motion-v test [test-file-name]`
 - Coverage: `pnpm --filter motion-v coverage`
@@ -40,7 +36,6 @@ The monorepo contains three main packages:
 - `packages/plugins/` - Nuxt module and resolver for unplugin-vue-components
 - `playground/nuxt/` - Nuxt playground (run with `pnpm play`)
 - `playground/vite/` - Vite playground for E2E tests (runs on port 5173)
-- `docs/` - Documentation site
 
 ### Core Components Architecture
 Motion components are built on top of Framer Motion's core, with Vue-specific adaptations:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,25 @@
+# Motion for Vue
+
+Vue port of Framer Motion ("motion"), published as `motion-v`. This glossary defines the project's canonical language; implementation details live in CLAUDE.md and the code.
+
+## Language
+
+**Parity （对齐）**:
+The porting convention: motion-vue matches framer-motion's behavior and capabilities 1:1, while Vue-idiomatic API naming is canonical and not considered a gap.
+_Avoid_: "exact copy", "bug-for-bug port"
+
+**Reorder Group**:
+A draggable list container that tracks item layouts and emits a new order for its `values` while dragging.
+_Avoid_: sortable list, drag list
+
+**Reorder Item**:
+A child of a Reorder Group bound to a single entry of `values`; dragging it drives the Group's reordering.
+_Avoid_: sortable item
+
+**Axis auto-detection**:
+When a Reorder Group's `axis` is omitted, the scroll/drag axis (`x`, `y`, or `xy` for grid layouts) is inferred from measured item layouts rather than defaulted.
+_Avoid_: fixed default axis
+
+**`onUpdate:values`**:
+The canonical Vue equivalent of React's `onReorder` callback; emitting `update:values` enables `v-model:values`.
+_Avoid_: onReorder

--- a/docs/adr/0001-parity-policy.md
+++ b/docs/adr/0001-parity-policy.md
@@ -1,0 +1,12 @@
+# Parity policy: behavior 1:1, Vue-idiomatic naming canonical
+
+When porting framer-motion features, motion-vue matches upstream behavior and capabilities 1:1, but Vue-idiomatic API naming is canonical and is not treated as a gap. The concrete case: Reorder keeps `onUpdate:values` (enabling `v-model:values`) instead of adopting React's `onReorder`, even while everything else about Reorder was brought to parity with framer-motion 13.1.0. No compatibility aliases are written — when upstream changes behavior, we replace directly and note breaking changes in the changelog.
+
+## Considered Options
+
+- **Rename to `onReorder` for literal API parity** — rejected: it would break existing Vue users to satisfy a naming correspondence, while `v-model:values` is the idiomatic Vue expression of the same contract. Parity is about behavior and capability, not prop names.
+
+## Consequences
+
+- Future ports apply the same rule: port behavior 1:1, keep established Vue idioms (v-model, slots), never add compat layers unless the maintainer explicitly asks.
+- Readers comparing motion-vue's API against React docs should expect naming differences of this kind; they are deliberate, not omissions.

--- a/packages/motion/src/components/reorder/Group.vue
+++ b/packages/motion/src/components/reorder/Group.vue
@@ -1,12 +1,13 @@
 <script lang="ts">
 import type { MotionProps } from '@/components/motion'
 import { Motion } from '@/components/motion'
-import type { ItemData } from './types'
+import type { ReorderAxis } from './types'
 import type { AsTag } from '@/types'
+import type { Box, Point } from 'motion-utils'
 import { invariant } from 'hey-listen'
-import { onUpdated, toRefs, useAttrs, watch } from 'vue'
+import { computed, onUpdated, ref, useAttrs } from 'vue'
 import { reorderContextProvider } from './context'
-import { checkReorder, compareMin, getValue } from './utils'
+import { checkReorder, detectAxis } from './utils'
 import { useDomRef } from '@/utils'
 </script>
 
@@ -15,12 +16,13 @@ import { useDomRef } from '@/utils'
 export interface GroupProps<T extends AsTag, K, V> extends
   MotionProps<T, K> {
   /**
-   * The axis to reorder along. By default, items will be draggable on this axis.
-   * To make draggable on both axes, set `<Reorder.Item drag />`
+   * The axis to reorder along. By default, the axis is auto-detected from
+   * the measured item layouts. Set `"xy"` to enable reordering in
+   * wrapped/grid layouts.
    *
    * @public
    */
-  'axis'?: 'x' | 'y'
+  'axis'?: ReorderAxis
   /**
    * A callback to fire with the new value order. For instance, if the values
    * are provided as a state from `useState`, this could be the set state function.
@@ -56,12 +58,13 @@ defineOptions({
 
 const props = withDefaults(defineProps<GroupProps<AsTag, K, V>>(), {
   as: 'ul',
-  axis: 'y',
 })
-const { axis } = toRefs(props)
 
-let order: ItemData<any>[] = []
+const itemLayouts = new Map<V, Box>()
+const detectedAxis = ref<ReorderAxis>('y')
 let isReordering = false
+
+const axis = computed<ReorderAxis>(() => props.axis || detectedAxis.value)
 
 function warning() {
   invariant(Boolean(props.values), 'Reorder.Group must be provided a values prop')
@@ -71,48 +74,56 @@ onUpdated(() => {
   isReordering = false
 })
 
-watch(() => props.values, () => {
-  // Only reset order if the values changed externally (not from our own reordering)
-  if (!isReordering) {
-    order = []
-  }
-}, {
-  flush: 'pre',
-})
-
 const groupRef = useDomRef()
 
 reorderContextProvider({
   groupRef,
   axis,
-  registerItem: (value, layout) => {
-    // Skip items that are no longer in the values list (e.g., exiting with AnimatePresence)
-    if (!props.values.includes(value))
-      return
-    // If the entry was already added, update it rather than adding it again
-    const idx = order.findIndex(entry => value === entry.value)
-    if (idx !== -1) {
-      order[idx].layout = layout[axis.value]
+  registerItem: (value: V, layout: Box) => {
+    // Prune layouts for values no longer in the list (e.g. removed or
+    // exiting with AnimatePresence)
+    const valuesSet = new Set(props.values)
+    itemLayouts.forEach((_, itemValue) => {
+      if (!valuesSet.has(itemValue))
+        itemLayouts.delete(itemValue)
+    })
+    itemLayouts.set(value, layout)
+    if (!props.axis) {
+      const nextAxis = detectAxis(props.values.flatMap((itemValue) => {
+        const itemLayout = itemLayouts.get(itemValue)
+        return itemLayout ? [itemLayout] : []
+      }))
+      if (nextAxis !== detectedAxis.value)
+        detectedAxis.value = nextAxis
     }
-    else {
-      order.push({ value, layout: layout[axis.value] })
-    }
-    order.sort(compareMin)
   },
-  updateOrder: (item: any, offset: number, velocity: number) => {
+  updateOrder: (item: V, offset: Point, velocity: Point) => {
     if (isReordering)
       return
 
-    const newOrder = checkReorder(order, item, offset, velocity)
+    // Build the order from the latest values so unmeasured items (e.g.
+    // entering/exiting with AnimatePresence) keep their positions
+    const order = props.values.flatMap((value) => {
+      const layout = itemLayouts.get(value)
+      return layout ? [{ value, layout }] : []
+    })
+
+    const element = groupRef.value
+    const direction = element?.ownerDocument.defaultView?.getComputedStyle(element).direction === 'rtl'
+      ? 'rtl' as const
+      : 'ltr' as const
+
+    const newOrder = checkReorder(order, item, offset, velocity, axis.value, direction)
     if (order !== newOrder) {
       isReordering = true
-      // Update the internal order array to match the new order
-      order = newOrder
-      props['onUpdate:values']?.(
-        newOrder
-          .map(getValue)
-          .filter(value => props.values.includes(value)),
-      )
+      // Remap the reordered measured items onto their slots in values,
+      // leaving unmeasured values in place
+      const newValues = [...props.values]
+      const measuredIndexes = order.map(({ value }) => props.values.indexOf(value))
+      newOrder.forEach(({ value }, index) => {
+        newValues[measuredIndexes[index]] = value
+      })
+      props['onUpdate:values']?.(newValues)
     }
   },
 })

--- a/packages/motion/src/components/reorder/Group.vue
+++ b/packages/motion/src/components/reorder/Group.vue
@@ -24,8 +24,8 @@ export interface GroupProps<T extends AsTag, K, V> extends
    */
   'axis'?: ReorderAxis
   /**
-   * A callback to fire with the new value order. For instance, if the values
-   * are provided as a state from `useState`, this could be the set state function.
+   * A callback to fire with the new value order. Use `v-model`
+   * to keep the values state in sync automatically.
    *
    * @public
    */
@@ -34,16 +34,10 @@ export interface GroupProps<T extends AsTag, K, V> extends
   /**
    * The latest values state.
    *
-   * ```jsx
-   * function Component() {
-   *   const [items, setItems] = useState([0, 1, 2])
-   *
-   *   return (
-   *     <Reorder.Group values={items} onReorder={setItems}>
-   *         {items.map((item) => <Reorder.Item key={item} value={item} />)}
-   *     </Reorder.Group>
-   *   )
-   * }
+   * ```vue
+   * <Reorder.Group v-model="items">
+   *   <Reorder.Item v-for="item in items" :key="item" :value="item" />
+   * </Reorder.Group>
    * ```
    *
    * @public

--- a/packages/motion/src/components/reorder/Item.vue
+++ b/packages/motion/src/components/reorder/Item.vue
@@ -86,7 +86,7 @@ const drag = computed(() => {
   if (props.drag) {
     return props.drag
   }
-  return axis.value
+  return axis.value === 'xy' ? true : axis.value
 })
 
 const isDragging = ref(false)
@@ -94,16 +94,20 @@ const isDragging = ref(false)
 // Track drag position for auto-scroll
 function handleDrag(event: PointerEvent, gesturePoint: any) {
   const { velocity, point: pointerPoint } = gesturePoint
-  const offset = point[axis.value].get()
+  const offset = { x: point.x.get(), y: point.y.get() }
 
   // Always attempt to update order - checkReorder handles the logic
-  updateOrder(props.value, offset, velocity[axis.value])
+  updateOrder(props.value, offset, velocity)
+
+  const scrollAxis = axis.value === 'xy'
+    ? (Math.abs(velocity.x) > Math.abs(velocity.y) ? 'x' : 'y')
+    : axis.value
 
   autoScrollIfNeeded(
     groupRef.value,
-    pointerPoint[axis.value],
-    axis.value,
-    velocity[axis.value],
+    pointerPoint[scrollAxis],
+    scrollAxis,
+    velocity[scrollAxis],
   )
   if (!isDragging.value)
     isDragging.value = true

--- a/packages/motion/src/components/reorder/Item.vue
+++ b/packages/motion/src/components/reorder/Item.vue
@@ -42,6 +42,7 @@ const props = withDefaults(defineProps<GroupItemProps<ElementType>>(), {
   layoutId: undefined,
   layoutScroll: false,
   layoutRoot: false,
+  drag: undefined,
   dragListener: true,
   dragElastic: 0.5,
   dragMomentum: true,
@@ -83,10 +84,10 @@ function bindProps() {
   }
 }
 const drag = computed(() => {
-  if (props.drag) {
+  if (props.drag !== undefined) {
     return props.drag
   }
-  return axis.value === 'xy' ? true : axis.value
+  return axis?.value === 'xy' ? true : axis?.value
 })
 
 const isDragging = ref(false)
@@ -97,17 +98,17 @@ function handleDrag(event: PointerEvent, gesturePoint: any) {
   const offset = { x: point.x.get(), y: point.y.get() }
 
   // Always attempt to update order - checkReorder handles the logic
-  updateOrder(props.value, offset, velocity)
+  updateOrder?.(props.value, offset, velocity)
 
-  const scrollAxis = axis.value === 'xy'
+  const scrollAxis = axis?.value === 'xy'
     ? (Math.abs(velocity.x) > Math.abs(velocity.y) ? 'x' : 'y')
-    : axis.value
+    : axis?.value
 
   autoScrollIfNeeded(
-    groupRef.value,
-    pointerPoint[scrollAxis],
-    scrollAxis,
-    velocity[scrollAxis],
+    groupRef?.value as Element,
+    pointerPoint?.[scrollAxis as 'x' | 'y'],
+    scrollAxis as 'x' | 'y',
+    velocity?.[scrollAxis as 'x' | 'y'],
   )
   if (!isDragging.value)
     isDragging.value = true
@@ -134,7 +135,7 @@ function handleDragStart(event: PointerEvent, gesturePoint: any) {
     @drag-end="handleDragEnd"
     @drag-start="handleDragStart"
     @layout-measure="(measured) => {
-      registerItem(value, measured)
+      registerItem?.(value, measured)
     }"
   >
     <slot :is-dragging="isDragging" />

--- a/packages/motion/src/components/reorder/__tests__/auto-scroll.test.ts
+++ b/packages/motion/src/components/reorder/__tests__/auto-scroll.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { autoScrollIfNeeded, resetAutoScrollState } from '../auto-scroll'
+
+function mockRect(
+  element: Element,
+  rect: { top: number, bottom: number, left: number, right: number },
+) {
+  element.getBoundingClientRect = () => ({
+    width: rect.right - rect.left,
+    height: rect.bottom - rect.top,
+    x: rect.left,
+    y: rect.top,
+    ...rect,
+    toJSON: () => ({}),
+  }) as DOMRect
+}
+
+function mockScrollProps(
+  element: Element,
+  props: { scrollHeight?: number, scrollWidth?: number, clientHeight?: number, clientWidth?: number, scrollTop?: number, scrollLeft?: number },
+) {
+  for (const [key, value] of Object.entries(props)) {
+    Object.defineProperty(element, key, { value, writable: true, configurable: true })
+  }
+}
+
+function setWindowScroll(x: number, y: number) {
+  Object.defineProperty(window, 'scrollX', { value: x, configurable: true })
+  Object.defineProperty(window, 'scrollY', { value: y, configurable: true })
+}
+
+describe('autoScrollIfNeeded', () => {
+  let scrollBySpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    scrollBySpy = vi.fn()
+    Object.defineProperty(window, 'scrollBy', { value: scrollBySpy, configurable: true, writable: true })
+    setWindowScroll(0, 0)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    resetAutoScrollState()
+  })
+
+  function createScrollableContainer() {
+    const container = document.createElement('div')
+    container.style.overflowY = 'auto'
+    const group = document.createElement('ul')
+    container.appendChild(group)
+    document.body.appendChild(container)
+    mockRect(container, { top: 0, bottom: 500, left: 0, right: 200 })
+    mockScrollProps(container, {
+      scrollHeight: 1000,
+      clientHeight: 500,
+      scrollTop: 0,
+      scrollLeft: 0,
+    })
+    return { container, group }
+  }
+
+  it('scrolls a scrollable container when dragging near its bottom edge', () => {
+    const { container, group } = createScrollableContainer()
+
+    autoScrollIfNeeded(group, 480, 'y', 5)
+
+    // intensity = 1 - 20/50 = 0.6, amount = 25 * 0.36 = 9
+    expect(container.scrollTop).toBeCloseTo(9)
+    expect(scrollBySpy).not.toHaveBeenCalled()
+  })
+
+  it('does not start scrolling when velocity points away from the edge', () => {
+    const { container, group } = createScrollableContainer()
+
+    autoScrollIfNeeded(group, 480, 'y', -5)
+
+    expect(container.scrollTop).toBe(0)
+  })
+
+  it('does not scroll outside the threshold zone', () => {
+    const { container, group } = createScrollableContainer()
+
+    autoScrollIfNeeded(group, 250, 'y', 5)
+
+    expect(container.scrollTop).toBe(0)
+  })
+
+  it('stops scrolling at the initially recorded scroll limit', () => {
+    const { container, group } = createScrollableContainer()
+    // Already scrolled to the limit recorded on first activation (1000 - 500)
+    container.scrollTop = 500
+
+    autoScrollIfNeeded(group, 480, 'y', 5)
+
+    expect(container.scrollTop).toBe(500)
+  })
+
+  it('keeps scrolling an active edge regardless of velocity until reset', () => {
+    const { container, group } = createScrollableContainer()
+
+    autoScrollIfNeeded(group, 480, 'y', 5)
+    const afterFirst = container.scrollTop
+    // Edge is active: velocity no longer gates scrolling
+    autoScrollIfNeeded(group, 480, 'y', 0)
+    expect(container.scrollTop).toBeGreaterThan(afterFirst)
+
+    // After reset, the velocity gate applies again
+    resetAutoScrollState()
+    const afterReset = container.scrollTop
+    autoScrollIfNeeded(group, 480, 'y', 0)
+    expect(container.scrollTop).toBe(afterReset)
+  })
+
+  describe('document scroll', () => {
+    function createPageGroup() {
+      const group = document.createElement('ul')
+      document.body.appendChild(group)
+      mockRect(document.body, { top: 0, bottom: 768, left: 0, right: 1024 })
+      mockScrollProps(document.body, { scrollHeight: 2000, clientHeight: 768 })
+      return group
+    }
+
+    it('scrolls the page when no scrollable ancestor exists', () => {
+      const group = createPageGroup()
+
+      autoScrollIfNeeded(group, 740, 'y', 5)
+
+      // intensity = 1 - 28/50 = 0.44, amount = 25 * 0.1936 = 4.84
+      expect(scrollBySpy).toHaveBeenCalledWith({ top: expect.closeTo(4.84) })
+    })
+
+    it('converts page coordinates to viewport coordinates', () => {
+      const group = createPageGroup()
+      setWindowScroll(0, 300)
+
+      // Page position 1040 is viewport position 740 — the same edge zone as
+      // the previous test, so the scroll amount must match it exactly
+      autoScrollIfNeeded(group, 1040, 'y', 5)
+
+      expect(scrollBySpy).toHaveBeenCalledWith({ top: expect.closeTo(4.84) })
+    })
+
+    it('scrolls the page horizontally', () => {
+      const group = createPageGroup()
+      mockRect(document.body, { top: 0, bottom: 768, left: 0, right: 1024 })
+      mockScrollProps(document.body, { scrollWidth: 3000, clientWidth: 1024 })
+
+      autoScrollIfNeeded(group, 990, 'x', 5)
+
+      // intensity = 1 - 34/50 = 0.32, amount = 25 * 0.1024 = 2.56
+      expect(scrollBySpy).toHaveBeenCalledWith({ left: expect.closeTo(2.56) })
+    })
+  })
+})

--- a/packages/motion/src/components/reorder/__tests__/check-reorder.test.ts
+++ b/packages/motion/src/components/reorder/__tests__/check-reorder.test.ts
@@ -1,0 +1,185 @@
+import type { ItemData } from '../types'
+import { describe, expect, it } from 'vitest'
+import { checkReorder, detectAxis } from '../utils'
+
+function itemData(
+  value: string,
+  xMin: number,
+  xMax: number,
+  yMin: number,
+  yMax: number,
+): ItemData<string> {
+  return {
+    value,
+    layout: {
+      x: { min: xMin, max: xMax },
+      y: { min: yMin, max: yMax },
+    },
+  }
+}
+
+describe('checkReorder', () => {
+  describe('one dimension', () => {
+    // a: x[0,100]  b: x[110,120]  c: x[130,230]  (all y[0,100])
+    const order = [
+      itemData('a', 0, 100, 0, 100),
+      itemData('b', 110, 120, 0, 100),
+      itemData('c', 130, 230, 0, 100),
+    ]
+    const values = () => order.map(item => item.value)
+
+    it('returns same array if velocity is 0', () => {
+      const newOrder = checkReorder(order, 'a', { x: 116, y: 0 }, { x: 0, y: 0 }, 'x')
+      expect(newOrder).toBe(order)
+    })
+
+    it('returns same array if value not found', () => {
+      const newOrder = checkReorder(order, 'd', { x: 116, y: 0 }, { x: 1, y: 0 }, 'x')
+      expect(newOrder).toBe(order)
+    })
+
+    it('returns same array if nextItem not found', () => {
+      const newOrder = checkReorder(order, 'c', { x: 300, y: 0 }, { x: 1, y: 0 }, 'x')
+      expect(newOrder).toBe(order)
+    })
+
+    it('returns same array if item has not passed the next item center', () => {
+      const newOrder = checkReorder(order, 'a', { x: 14, y: 0 }, { x: 2, y: 0 }, 'x')
+      expect(newOrder).toBe(order)
+    })
+
+    it('returns reordered array if item has moved right', () => {
+      const newOrder = checkReorder(order, 'a', { x: 16, y: 0 }, { x: 1.5, y: 0 }, 'x')
+      expect(newOrder).not.toBe(order)
+      expect(newOrder.map(item => item.value)).toEqual(['b', 'a', 'c'])
+    })
+
+    it('returns reordered array if item has moved down', () => {
+      const newOrder = checkReorder(order, 'a', { x: 0, y: 15 }, { x: 0, y: 1 }, 'y')
+      expect(newOrder.map(item => item.value)).toEqual(['b', 'a', 'c'])
+    })
+
+    it('returns reordered array if item has moved left', () => {
+      const newOrder = checkReorder(order, 'b', { x: -61, y: 0 }, { x: -2, y: 0 }, 'x')
+      expect(newOrder.map(item => item.value)).toEqual(['b', 'a', 'c'])
+    })
+
+    it('returns reordered array if item has moved up', () => {
+      const newOrder = checkReorder(order, 'b', { x: 0, y: -61 }, { x: 0, y: -1 }, 'y')
+      expect(newOrder.map(item => item.value)).toEqual(['b', 'a', 'c'])
+    })
+
+    it('does not mutate the input order', () => {
+      checkReorder(order, 'a', { x: 16, y: 0 }, { x: 1.5, y: 0 }, 'x')
+      expect(values()).toEqual(['a', 'b', 'c'])
+    })
+  })
+
+  describe('two dimensions', () => {
+    // line 1 (y[0,100]):  a: x[0,100]   b: x[110,120]  c: x[130,230]
+    // line 2 (y[110,120]): d: x[0,100]  e: x[110,120]
+    const order = [
+      itemData('a', 0, 100, 0, 100),
+      itemData('b', 110, 120, 0, 100),
+      itemData('c', 130, 230, 0, 100),
+      itemData('d', 0, 100, 110, 120),
+      itemData('e', 110, 120, 110, 120),
+    ]
+    const valuesOf = (items: ItemData<string>[]) => items.map(item => item.value)
+
+    it('returns reordered array if item has moved left within its line', () => {
+      const newOrder = checkReorder(order, 'e', { x: -61, y: 0 }, { x: -1, y: 0 }, 'xy')
+      expect(valuesOf(newOrder)).toEqual(['a', 'b', 'c', 'e', 'd'])
+    })
+
+    it('returns reordered array if item has moved right within its line', () => {
+      const newOrder = checkReorder(order, 'a', { x: 63, y: 0 }, { x: 1, y: 0 }, 'xy')
+      expect(valuesOf(newOrder)).toEqual(['b', 'a', 'c', 'd', 'e'])
+    })
+
+    it('returns same array if first item of a line is moved left', () => {
+      const newOrder = checkReorder(order, 'a', { x: -1, y: 0 }, { x: 1, y: 0 }, 'xy')
+      expect(newOrder).toBe(order)
+    })
+
+    it('returns same array if last item of a line is moved right', () => {
+      const newOrder = checkReorder(order, 'c', { x: 1, y: 0 }, { x: 5, y: 0 }, 'xy')
+      expect(newOrder).toBe(order)
+    })
+
+    it('returns reordered array if item has moved up to the previous line', () => {
+      const newOrder = checkReorder(order, 'e', { x: 0, y: -61 }, { x: 0, y: -1 }, 'xy')
+      expect(valuesOf(newOrder)).toEqual(['a', 'b', 'e', 'c', 'd'])
+    })
+
+    it('returns reordered array if item has moved down to the next line', () => {
+      const newOrder = checkReorder(order, 'a', { x: 0, y: 62 }, { x: 0, y: 1 }, 'xy')
+      expect(valuesOf(newOrder)).toEqual(['b', 'c', 'd', 'a', 'e'])
+    })
+
+    it('returns same array if item is moved up from the first line', () => {
+      const newOrder = checkReorder(order, 'a', { x: 0, y: -61 }, { x: 0, y: -1 }, 'xy')
+      expect(newOrder).toBe(order)
+    })
+
+    it('returns same array if item is moved down from the last line', () => {
+      const newOrder = checkReorder(order, 'e', { x: 0, y: 62 }, { x: 0, y: 1 }, 'xy')
+      expect(newOrder).toBe(order)
+    })
+
+    it('inserts after the hovered item when direction is rtl', () => {
+      const ltrOrder = checkReorder(order, 'a', { x: 0, y: 62 }, { x: 0, y: 1 }, 'xy', 'ltr')
+      const rtlOrder = checkReorder(order, 'a', { x: 0, y: 62 }, { x: 0, y: 1 }, 'xy', 'rtl')
+      expect(valuesOf(ltrOrder)).toEqual(['b', 'c', 'd', 'a', 'e'])
+      expect(valuesOf(rtlOrder)).toEqual(['b', 'c', 'd', 'e', 'a'])
+    })
+  })
+})
+
+describe('detectAxis', () => {
+  it('detects axis of horizontally-arranged items', () => {
+    expect(detectAxis([
+      { x: { min: 0, max: 100 }, y: { min: 0, max: 100 } },
+      { x: { min: 100, max: 200 }, y: { min: 0, max: 100 } },
+    ])).toBe('x')
+
+    expect(detectAxis([
+      { x: { min: 0, max: 100 }, y: { min: 0, max: 100 } },
+      { x: { min: 101, max: 200 }, y: { min: 40, max: 60 } },
+    ])).toBe('x')
+  })
+
+  it('detects axis of vertically-arranged items', () => {
+    expect(detectAxis([
+      { x: { min: 0, max: 100 }, y: { min: 0, max: 100 } },
+      { x: { min: 0, max: 200 }, y: { min: 100, max: 200 } },
+    ])).toBe('y')
+
+    expect(detectAxis([
+      { x: { min: 40, max: 60 }, y: { min: 0, max: 100 } },
+      { x: { min: 0, max: 100 }, y: { min: 100, max: 200 } },
+    ])).toBe('y')
+  })
+
+  it('detects xy for grid-arranged items', () => {
+    expect(detectAxis([
+      { x: { min: 0, max: 100 }, y: { min: 0, max: 100 } },
+      { x: { min: 200, max: 300 }, y: { min: 0, max: 100 } },
+      { x: { min: 0, max: 100 }, y: { min: 200, max: 300 } },
+    ])).toBe('xy')
+
+    // Diagonally-arranged items are separated on both axes
+    expect(detectAxis([
+      { x: { min: 0, max: 100 }, y: { min: 0, max: 100 } },
+      { x: { min: 200, max: 300 }, y: { min: 200, max: 300 } },
+    ])).toBe('xy')
+  })
+
+  it('defaults to y for single or no measured items', () => {
+    expect(detectAxis([
+      { x: { min: 0, max: 100 }, y: { min: 0, max: 100 } },
+    ])).toBe('y')
+
+    expect(detectAxis([])).toBe('y')
+  })
+})

--- a/packages/motion/src/components/reorder/auto-scroll.ts
+++ b/packages/motion/src/components/reorder/auto-scroll.ts
@@ -36,10 +36,14 @@ export function resetAutoScrollState(): void {
   }
 }
 
+function isDocumentScroll(element: Element): boolean {
+  return element === document.body || element === document.documentElement
+}
+
 function isScrollableElement(element: Element, axis: 'x' | 'y'): boolean {
   const style = getComputedStyle(element)
   const overflow = axis === 'x' ? style.overflowX : style.overflowY
-  return overflowStyles.has(overflow)
+  return overflowStyles.has(overflow) || isDocumentScroll(element)
 }
 
 function findScrollableAncestor(
@@ -49,7 +53,7 @@ function findScrollableAncestor(
   let current = element?.parentElement
   while (current) {
     if (isScrollableElement(current, axis)) {
-      return current
+      return current as HTMLElement
     }
     current = current.parentElement
   }
@@ -63,8 +67,10 @@ function getScrollAmount(
 ): { amount: number, edge: ActiveEdge } {
   const rect = scrollElement.getBoundingClientRect()
 
-  const start = axis === 'x' ? rect.left : rect.top
-  const end = axis === 'x' ? rect.right : rect.bottom
+  // Clamp the scrollable element's edges to the viewport, as it may
+  // extend beyond the visible area
+  const start = axis === 'x' ? Math.max(0, rect.left) : Math.max(0, rect.top)
+  const end = axis === 'x' ? Math.min(window.innerWidth, rect.right) : Math.min(window.innerHeight, rect.bottom)
 
   const distanceFromStart = pointerPosition - start
   const distanceFromEnd = end - pointerPosition
@@ -97,8 +103,13 @@ export function autoScrollIfNeeded(
   if (!scrollableAncestor)
     return
 
+  // Convert pointer position from page coordinates to viewport coordinates.
+  // The gesture system uses pageX/pageY but getBoundingClientRect() returns
+  // viewport-relative coordinates, so we need to account for page scroll.
+  const viewportPointerPosition = pointerPosition - (axis === 'x' ? window.scrollX : window.scrollY)
+
   const { amount: scrollAmount, edge } = getScrollAmount(
-    pointerPosition,
+    viewportPointerPosition,
     scrollableAncestor,
     axis,
   )
@@ -111,6 +122,7 @@ export function autoScrollIfNeeded(
   }
 
   const currentActiveEdge = activeScrollEdge.get(scrollableAncestor)
+  const isDocument = isDocumentScroll(scrollableAncestor)
 
   // If not currently scrolling this edge, check velocity to see if we should start
   if (currentActiveEdge !== edge) {
@@ -128,9 +140,9 @@ export function autoScrollIfNeeded(
     const maxScroll
             = axis === 'x'
               ? scrollableAncestor.scrollWidth
-              - scrollableAncestor.clientWidth
+              - (isDocument ? window.innerWidth : scrollableAncestor.clientWidth)
               : scrollableAncestor.scrollHeight
-              - scrollableAncestor.clientHeight
+              - (isDocument ? window.innerHeight : scrollableAncestor.clientHeight)
     initialScrollLimits.set(scrollableAncestor, maxScroll)
   }
 
@@ -139,17 +151,27 @@ export function autoScrollIfNeeded(
     const initialLimit = initialScrollLimits.get(scrollableAncestor)!
     const currentScroll
             = axis === 'x'
-              ? scrollableAncestor.scrollLeft
-              : scrollableAncestor.scrollTop
+              ? (isDocument ? window.scrollX : scrollableAncestor.scrollLeft)
+              : (isDocument ? window.scrollY : scrollableAncestor.scrollTop)
     if (currentScroll >= initialLimit)
       return
   }
 
   // Apply scroll
   if (axis === 'x') {
-    scrollableAncestor.scrollLeft += scrollAmount
+    if (isDocument) {
+      window.scrollBy({ left: scrollAmount })
+    }
+    else {
+      scrollableAncestor.scrollLeft += scrollAmount
+    }
   }
   else {
-    scrollableAncestor.scrollTop += scrollAmount
+    if (isDocument) {
+      window.scrollBy({ top: scrollAmount })
+    }
+    else {
+      scrollableAncestor.scrollTop += scrollAmount
+    }
   }
 }

--- a/packages/motion/src/components/reorder/context.ts
+++ b/packages/motion/src/components/reorder/context.ts
@@ -1,11 +1,13 @@
 import { createContext } from '@/utils'
 import type { Box } from 'framer-motion'
+import type { Point } from 'motion-utils'
 import type { Ref } from 'vue'
+import type { ReorderAxis } from './types'
 
 export interface ReorderContextProps<T> {
-  axis?: Ref<'x' | 'y'>
+  axis?: Ref<ReorderAxis>
   registerItem?: (item: T, layout: Box) => void
-  updateOrder?: (item: T, offset: number, velocity: number) => void
+  updateOrder?: (item: T, offset: Point, velocity: Point) => void
 
   groupRef?: Ref<HTMLElement | null>
 }

--- a/packages/motion/src/components/reorder/types.ts
+++ b/packages/motion/src/components/reorder/types.ts
@@ -1,6 +1,8 @@
-import type { Axis } from 'framer-motion'
+import type { Box } from 'framer-motion'
+
+export type ReorderAxis = 'x' | 'y' | 'xy'
 
 export interface ItemData<T> {
   value: T
-  layout: Axis
+  layout: Box
 }

--- a/packages/motion/src/components/reorder/utils.ts
+++ b/packages/motion/src/components/reorder/utils.ts
@@ -1,44 +1,74 @@
-import type { ItemData } from '@/components/reorder/types'
+import type { ItemData, ReorderAxis } from '@/components/reorder/types'
+import type { Axis, Box, Point } from 'motion-utils'
 import { isMotionValue, mixNumber, motionValue } from 'framer-motion/dom'
-
-export function compareMin<V>(a: ItemData<V>, b: ItemData<V>) {
-  return a.layout.min - b.layout.min
-}
-
-export function getValue<V>(item: ItemData<V>) {
-  return item.value
-}
+import { moveItem } from 'motion-utils'
 
 export function checkReorder<T>(
   order: ItemData<T>[],
   value: T,
-  offset: number,
-  velocity: number,
+  offset: Point,
+  velocity: Point,
+  axis: ReorderAxis,
+  direction: 'ltr' | 'rtl' = 'ltr',
 ): ItemData<T>[] {
   const index = order.findIndex(item => item.value === value)
   if (index === -1)
     return order
 
-  // Determine direction from velocity, fallback to offset if velocity is zero
-  const direction = velocity !== 0 ? velocity : offset
+  if (axis === 'xy') {
+    const { layout } = order[index]
+    const center = {
+      x: mixNumber(layout.x.min, layout.x.max, 0.5) + offset.x,
+      y: mixNumber(layout.y.min, layout.y.max, 0.5) + offset.y,
+    }
 
-  // If no movement, return early
-  if (!direction)
+    const lines = getLines(order)
+    const sourceLine = lines.find(line => line.items.includes(order[index]))
+    const targetLine = lines.reduce((closest, line) =>
+      distanceToLine(center.y, line) < distanceToLine(center.y, closest)
+        ? line
+        : closest,
+    )
+
+    if (targetLine !== sourceLine) {
+      return moveToLine(order, index, center.x, targetLine, direction)
+    }
+
+    const currentDistance = distanceToBox(center, layout)
+    let target = -1
+    let targetDistance = currentDistance
+    order.forEach((item, targetIndex) => {
+      if (targetIndex === index)
+        return
+      const distance = distanceToBox(center, item.layout)
+      if (distance < targetDistance) {
+        target = targetIndex
+        targetDistance = distance
+      }
+    })
+
+    return target === -1
+      ? order
+      : moveItem(order, index, index + Math.sign(target - index))
+  }
+
+  if (!velocity[axis])
     return order
 
-  const nextOffset = direction > 0 ? 1 : -1
+  const nextOffset = velocity[axis] > 0 ? 1 : -1
   const nextItem = order[index + nextOffset]
 
   if (!nextItem)
     return order
 
   const item = order[index]
-  const nextLayout = nextItem.layout
+  const itemLayout = item.layout[axis]
+  const nextLayout = nextItem.layout[axis]
   const nextItemCenter = mixNumber(nextLayout.min, nextLayout.max, 0.5)
 
   if (
-    (nextOffset === 1 && item.layout.max + offset > nextItemCenter)
-    || (nextOffset === -1 && item.layout.min + offset < nextItemCenter)
+    (nextOffset === 1 && itemLayout.max + offset[axis] > nextItemCenter)
+    || (nextOffset === -1 && itemLayout.min + offset[axis] < nextItemCenter)
   ) {
     return moveItem(order, index, index + nextOffset)
   }
@@ -46,17 +76,77 @@ export function checkReorder<T>(
   return order
 }
 
-export function moveItem<T>([...arr]: T[], fromIndex: number, toIndex: number) {
-  const startIndex = fromIndex < 0 ? arr.length + fromIndex : fromIndex
+interface Line<T> {
+  items: ItemData<T>[]
+  min: number
+  max: number
+}
 
-  if (startIndex >= 0 && startIndex < arr.length) {
-    const endIndex = toIndex < 0 ? arr.length + toIndex : toIndex
+function getLines<T>(order: ItemData<T>[]): Line<T>[] {
+  const lines: Line<T>[] = []
+  order.forEach((item) => {
+    const { min, max } = item.layout.y
+    const line = lines[lines.length - 1]
+    if (!line || min >= line.max || max <= line.min) {
+      lines.push({ items: [item], min, max })
+    }
+    else {
+      line.items.push(item)
+      line.min = Math.min(line.min, min)
+      line.max = Math.max(line.max, max)
+    }
+  })
+  return lines
+}
 
-    const [item] = arr.splice(fromIndex, 1)
-    arr.splice(endIndex, 0, item)
+function distanceToLine<T>(y: number, line: Line<T>): number {
+  return y < line.min ? line.min - y : y > line.max ? y - line.max : 0
+}
+
+function moveToLine<T>(
+  order: ItemData<T>[],
+  index: number,
+  x: number,
+  line: Line<T>,
+  direction: 'ltr' | 'rtl',
+): ItemData<T>[] {
+  const remaining = order.filter((_, itemIndex) => itemIndex !== index)
+  const before = line.items.find((item) => {
+    const center = mixNumber(item.layout.x.min, item.layout.x.max, 0.5)
+    return direction === 'ltr' ? x < center : x > center
+  })
+  const targetIndex = before
+    ? remaining.indexOf(before)
+    : remaining.indexOf(line.items[line.items.length - 1]) + 1
+
+  const nextOrder = [...remaining]
+  nextOrder.splice(targetIndex, 0, order[index])
+
+  return nextOrder.every((item, itemIndex) => item === order[itemIndex])
+    ? order
+    : nextOrder
+}
+
+function distanceToBox(point: Point, box: Box): number {
+  const x = Math.max(box.x.min - point.x, 0, point.x - box.x.max)
+  const y = Math.max(box.y.min - point.y, 0, point.y - box.y.max)
+  return x * x + y * y
+}
+
+const isSeparated = (a: Axis, b: Axis) => a.max <= b.min || b.max <= a.min
+
+export function detectAxis(layouts: Box[]): ReorderAxis {
+  let x = false
+  let y = false
+  for (let i = 0; i < layouts.length; i++) {
+    for (let j = i + 1; j < layouts.length; j++) {
+      x ||= isSeparated(layouts[i].x, layouts[j].x)
+      y ||= isSeparated(layouts[i].y, layouts[j].y)
+      if (x && y)
+        return 'xy'
+    }
   }
-
-  return arr
+  return x ? 'x' : 'y'
 }
 
 export function useDefaultMotionValue(value: any, defaultValue: number = 0) {

--- a/playground/vite/src/views/reorder/auto-detect.vue
+++ b/playground/vite/src/views/reorder/auto-detect.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Reorder } from 'motion-v'
+
+const items = ref([0, 1, 2, 3, 4, 5])
+</script>
+
+<template>
+  <div class="p-8">
+    <h1 class="text-2xl font-bold mb-4">
+      Reorder Auto-Detect (horizontal, no axis prop)
+    </h1>
+    <p
+      data-testid="order"
+      class="mb-4 text-sm text-gray-500"
+    >
+      {{ items.join(',') }}
+    </p>
+
+    <Reorder.Group
+      v-model:values="items"
+      class="flex gap-2"
+    >
+      <Reorder.Item
+        v-for="item in items"
+        :key="item"
+        :value="item"
+        :data-testid="`h-${item}`"
+        class="bg-white rounded shadow-sm border cursor-grab active:cursor-grabbing flex items-center justify-center font-medium"
+        style="list-style: none; width: 80px; height: 80px;"
+      >
+        {{ item }}
+      </Reorder.Item>
+    </Reorder.Group>
+  </div>
+</template>

--- a/playground/vite/src/views/reorder/grid.vue
+++ b/playground/vite/src/views/reorder/grid.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Reorder } from 'motion-v'
+
+const items = ref([0, 1, 2, 3, 4, 5])
+</script>
+
+<template>
+  <div class="p-8">
+    <h1 class="text-2xl font-bold mb-4">
+      Reorder Grid (axis="xy")
+    </h1>
+    <p
+      data-testid="order"
+      class="mb-4 text-sm text-gray-500"
+    >
+      {{ items.join(',') }}
+    </p>
+
+    <Reorder.Group
+      v-model:values="items"
+      axis="xy"
+      class="flex flex-wrap gap-2"
+      style="width: 392px;"
+    >
+      <Reorder.Item
+        v-for="item in items"
+        :key="item"
+        :value="item"
+        :data-testid="`g-${item}`"
+        class="bg-white rounded shadow-sm border cursor-grab active:cursor-grabbing flex items-center justify-center font-medium"
+        style="list-style: none; width: 120px; height: 80px;"
+      >
+        {{ item }}
+      </Reorder.Item>
+    </Reorder.Group>
+  </div>
+</template>

--- a/playground/vite/src/views/reorder/index.vue
+++ b/playground/vite/src/views/reorder/index.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Reorder } from 'motion-v'
+
+const items = ref([0, 1, 2, 3, 4, 5])
+</script>
+
+<template>
+  <div class="p-8">
+    <h1 class="text-2xl font-bold mb-4">
+      Reorder Basic (axis auto-detected)
+    </h1>
+    <p
+      data-testid="order"
+      class="mb-4 text-sm text-gray-500"
+    >
+      {{ items.join(',') }}
+    </p>
+
+    <Reorder.Group
+      v-model:values="items"
+      class="space-y-2 w-64"
+    >
+      <Reorder.Item
+        v-for="item in items"
+        :key="item"
+        :value="item"
+        :data-testid="`item-${item}`"
+        class="bg-white p-4 rounded shadow-sm border cursor-grab active:cursor-grabbing"
+        style="list-style: none;"
+      >
+        Item {{ item }}
+      </Reorder.Item>
+    </Reorder.Group>
+  </div>
+</template>

--- a/playground/vite/src/views/reorder/page-scroll.vue
+++ b/playground/vite/src/views/reorder/page-scroll.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Reorder } from 'motion-v'
+
+const items = ref(Array.from({ length: 30 }, (_, i) => i))
+</script>
+
+<template>
+  <div class="p-8">
+    <h1 class="text-2xl font-bold mb-4">
+      Reorder Page Scroll (no overflow container)
+    </h1>
+    <p class="text-sm text-gray-600 mb-4">
+      The list is taller than the viewport and the page itself scrolls.
+      Drag an item to the bottom edge of the window to scroll the page.
+    </p>
+    <p
+      data-testid="order"
+      class="mb-4 text-sm text-gray-500"
+    >
+      {{ items.join(',') }}
+    </p>
+
+    <Reorder.Group
+      v-model:values="items"
+      axis="y"
+      class="space-y-2 w-64"
+    >
+      <Reorder.Item
+        v-for="item in items"
+        :key="item"
+        :value="item"
+        :data-testid="`p-${item}`"
+        class="bg-white p-4 rounded shadow-sm border cursor-grab active:cursor-grabbing"
+        style="list-style: none;"
+      >
+        Item {{ item }}
+      </Reorder.Item>
+    </Reorder.Group>
+  </div>
+</template>

--- a/playground/vite/src/views/reorder/rtl.vue
+++ b/playground/vite/src/views/reorder/rtl.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Reorder } from 'motion-v'
+
+const items = ref([0, 1, 2, 3, 4, 5])
+</script>
+
+<template>
+  <div
+    dir="rtl"
+    class="p-8"
+  >
+    <h1 class="text-2xl font-bold mb-4">
+      Reorder RTL Grid (axis="xy")
+    </h1>
+    <p
+      data-testid="order"
+      class="mb-4 text-sm text-gray-500"
+    >
+      {{ items.join(',') }}
+    </p>
+
+    <Reorder.Group
+      v-model:values="items"
+      axis="xy"
+      class="flex flex-wrap gap-2"
+      style="width: 392px;"
+    >
+      <Reorder.Item
+        v-for="item in items"
+        :key="item"
+        :value="item"
+        :data-testid="`r-${item}`"
+        class="bg-white rounded shadow-sm border cursor-grab active:cursor-grabbing flex items-center justify-center font-medium"
+        style="list-style: none; width: 120px; height: 80px;"
+      >
+        {{ item }}
+      </Reorder.Item>
+    </Reorder.Group>
+  </div>
+</template>

--- a/tests/reorder-page-scroll.spec.ts
+++ b/tests/reorder-page-scroll.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Tests for Reorder page-level auto-scroll: when the Reorder container has
+ * no overflow:auto/scroll ancestor, dragging near the viewport edge scrolls
+ * the page itself.
+ */
+test.describe('Reorder page scroll', () => {
+  test('scrolls the page when dragging near the viewport bottom edge', async ({ page }) => {
+    await page.goto('/reorder/page-scroll')
+    await page.waitForTimeout(200)
+
+    const initialScroll = await page.evaluate(() => window.scrollY)
+    expect(initialScroll).toBe(0)
+
+    const item0 = page.locator('[data-testid="p-0"]')
+    const box = await item0.boundingBox()
+    expect(box).not.toBeNull()
+
+    const startX = box!.x + box!.width / 2
+    const startY = box!.y + box!.height / 2
+
+    await page.mouse.move(startX, startY)
+    await page.mouse.down()
+    await page.waitForTimeout(50)
+
+    // Initiate the drag, then move to just above the viewport bottom edge
+    const viewportHeight = page.viewportSize()!.height
+    await page.mouse.move(startX, startY + 30, { steps: 5 })
+    await page.mouse.move(startX, viewportHeight - 20, { steps: 10 })
+    await page.waitForTimeout(300)
+
+    const afterScroll = await page.evaluate(() => window.scrollY)
+    expect(afterScroll).toBeGreaterThan(0)
+
+    await page.mouse.up()
+  })
+})

--- a/tests/reorder.spec.ts
+++ b/tests/reorder.spec.ts
@@ -1,0 +1,131 @@
+import type { Page } from '@playwright/test'
+import { expect, test } from '@playwright/test'
+
+/**
+ * Tests for Reorder axis auto-detection, grid ("xy") reordering and RTL.
+ */
+
+async function getOrder(page: Page): Promise<string> {
+  return (await page.locator('[data-testid="order"]').textContent())!.trim()
+}
+
+async function dragItemTo(page: Page, testId: string, targetX: number, targetY: number) {
+  const item = page.locator(`[data-testid="${testId}"]`)
+  const box = await item.boundingBox()
+  expect(box).not.toBeNull()
+  const startX = box!.x + box!.width / 2
+  const startY = box!.y + box!.height / 2
+  await page.mouse.move(startX, startY)
+  await page.mouse.down()
+  await page.waitForTimeout(50)
+  await page.mouse.move(targetX, targetY, { steps: 12 })
+  await page.waitForTimeout(200)
+}
+
+test.describe('Reorder basic (axis auto-detected)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/reorder')
+    await page.waitForTimeout(200)
+  })
+
+  test('reorders a vertical list without an explicit axis', async ({ page }) => {
+    expect(await getOrder(page)).toBe('0,1,2,3,4,5')
+
+    // Drag item 0 onto item 1's position
+    const item1Box = await page.locator('[data-testid="item-1"]').boundingBox()
+    expect(item1Box).not.toBeNull()
+    await dragItemTo(page, 'item-0', item1Box!.x + item1Box!.width / 2, item1Box!.y + item1Box!.height / 2 + 4)
+
+    expect(await getOrder(page)).toBe('1,0,2,3,4,5')
+    await page.mouse.up()
+
+    // Order persists after release
+    await page.waitForTimeout(300)
+    expect(await getOrder(page)).toBe('1,0,2,3,4,5')
+  })
+})
+
+test.describe('Reorder axis auto-detection', () => {
+  test('detects horizontal axis for a horizontal list', async ({ page }) => {
+    await page.goto('/reorder/auto-detect')
+    await page.waitForTimeout(200)
+
+    expect(await getOrder(page)).toBe('0,1,2,3,4,5')
+
+    // Drag item 0 onto item 1's position — only possible if the detected
+    // axis is "x"
+    const item1Box = await page.locator('[data-testid="h-1"]').boundingBox()
+    expect(item1Box).not.toBeNull()
+    await dragItemTo(page, 'h-0', item1Box!.x + item1Box!.width / 2 + 4, item1Box!.y + item1Box!.height / 2)
+
+    expect(await getOrder(page)).toBe('1,0,2,3,4,5')
+    await page.mouse.up()
+  })
+})
+
+test.describe('Reorder grid (axis="xy")', () => {
+  test('reorders across lines in a wrapped grid', async ({ page }) => {
+    await page.goto('/reorder/grid')
+    await page.waitForTimeout(200)
+
+    expect(await getOrder(page)).toBe('0,1,2,3,4,5')
+
+    // Drag item 0 straight down into the second row (same column)
+    const item0Box = await page.locator('[data-testid="g-0"]').boundingBox()
+    const item3Box = await page.locator('[data-testid="g-3"]').boundingBox()
+    expect(item0Box).not.toBeNull()
+    expect(item3Box).not.toBeNull()
+    await dragItemTo(
+      page,
+      'g-0',
+      item0Box!.x + item0Box!.width / 2,
+      item3Box!.y + item3Box!.height / 2,
+    )
+
+    // LTR: item 0 is inserted before the item to its right on the new line
+    expect(await getOrder(page)).toBe('1,2,3,0,4,5')
+    await page.mouse.up()
+  })
+
+  test('reorders within the same line', async ({ page }) => {
+    await page.goto('/reorder/grid')
+    await page.waitForTimeout(200)
+
+    // Drag item 0 onto item 1's position (same row)
+    const item1Box = await page.locator('[data-testid="g-1"]').boundingBox()
+    expect(item1Box).not.toBeNull()
+    await dragItemTo(page, 'g-0', item1Box!.x + item1Box!.width / 2, item1Box!.y + item1Box!.height / 2)
+
+    expect(await getOrder(page)).toBe('1,0,2,3,4,5')
+    await page.mouse.up()
+  })
+})
+
+test.describe('Reorder RTL', () => {
+  test('uses computed direction when inserting into another line', async ({ page }) => {
+    await page.goto('/reorder/rtl')
+    await page.waitForTimeout(200)
+
+    expect(await getOrder(page)).toBe('0,1,2,3,4,5')
+
+    // In RTL the first item is rightmost. Drag it straight down into the
+    // second row without crossing any other item.
+    const item0Box = await page.locator('[data-testid="r-0"]').boundingBox()
+    const item3Box = await page.locator('[data-testid="r-3"]').boundingBox()
+    expect(item0Box).not.toBeNull()
+    expect(item3Box).not.toBeNull()
+    await dragItemTo(
+      page,
+      'r-0',
+      item0Box!.x + item0Box!.width / 2,
+      item3Box!.y + item3Box!.height / 2,
+    )
+
+    // With direction detection working, item 0 is inserted before the
+    // visually-next item ("1,2,3,0,4,5"). If RTL detection were broken
+    // (always "ltr"), the same gesture would append it to the end of the
+    // line instead ("1,2,3,4,5,0").
+    expect(await getOrder(page)).toBe('1,2,3,0,4,5')
+    await page.mouse.up()
+  })
+})


### PR DESCRIPTION
## Summary

Ports the Reorder features that shipped in framer-motion 13.x (`motiondivision/motion` #1685, multidimensional reorder) to bring motion-vue to full behavior parity with framer-motion 13.1.0:

- **Grid / 2D reordering** — `axis` widened to `'x' | 'y' | 'xy'` and is now **optional with auto-detection** (`detectAxis` infers the axis from measured item layouts); `checkReorder` rewritten as a 2D algorithm (`getLines`/`moveToLine`/`distanceToBox`)
- **RTL support** — insertion direction follows the group's computed `direction`
- **Map-based layout registry** — full `Box` storage, stale-value pruning, order rebuilt from the latest `values`, `measuredIndexes` remap so unmeasured (e.g. AnimatePresence-exiting) items keep their positions
- **Page-level auto-scroll** — when no `overflow: auto/scroll` ancestor exists the page itself scrolls (`window.scrollBy`); pointer coordinates converted page→viewport; edges clamped to the viewport
- **Item** — passes `{x, y}` offset/velocity, drags on both axes in `xy` mode (an explicit `drag` prop still wins), auto-scrolls along the dominant velocity axis
- `moveItem` now imported from `motion-utils` (local copy dropped)

## Behavior change

A `Reorder.Group` without an `axis` prop previously behaved as `axis="y"`; it now auto-detects, so horizontal lists work without an explicit `axis`. `v-model:values` / `onUpdate:values` is unchanged (see `docs/adr/0001-parity-policy.md` for the parity convention).

The local `checkReorder` divergence (offset fallback when velocity is 0, introduced in 359c9bc) is dropped in favor of the upstream algorithm: no test guarded it, and the new values-derived order rebuilding covers the continuous-reordering fix from the same commit.

## Tests

- **Unit** (+30): 2D `checkReorder` (in-line moves, cross-line moves, edges, RTL vs LTR), `detectAxis`, auto-scroll (container edges, velocity gating, scroll cap, reset, document/page scroll, page→viewport coordinate conversion)
- **E2E** (+6 × chromium/webkit): basic vertical (auto-detected axis), horizontal auto-detection, `xy` grid cross-line & same-line drags, RTL grid, page-level auto-scroll
- Full suites green: 160 unit, 94 E2E

## Notes

- Docs site intentionally not updated (decided in planning); the new capabilities ship in the changelog only.
- Reference source: npm `framer-motion@13.1.0` dist (the React 19-specific drag fix `a5e96c344` is N/A — the Vue drag feature never ends pan sessions on unmount).